### PR TITLE
Add minimal JSON load test for animals

### DIFF
--- a/tests/test_animals_load.c
+++ b/tests/test_animals_load.c
@@ -6,54 +6,33 @@
 #include <string.h>
 #include <unistd.h>
 
-static void copy_animals_json(const char *dst_dir)
-{
-    char src_path[512];
-    snprintf(src_path, sizeof(src_path), "../data/animals.json");
-    FILE *src = fopen(src_path, "rb");
-    assert(src);
-
-    char dst_path[512];
-    snprintf(dst_path, sizeof(dst_path), "%s/animals.json", dst_dir);
-    FILE *dst = fopen(dst_path, "wb");
-    assert(dst);
-
-    char buf[128];
-    size_t n;
-    while ((n = fread(buf, 1, sizeof(buf), src)) > 0) {
-        fwrite(buf, 1, n, dst);
-    }
-
-    fclose(src);
-    fclose(dst);
-}
-
 int main(void)
 {
     char tmp_template[] = "/tmp/animalsXXXXXX";
     char *tmpdir = mkdtemp(tmp_template);
     assert(tmpdir);
 
-    copy_animals_json(tmpdir);
+    char json_path[512];
+    snprintf(json_path, sizeof(json_path), "%s/animals.json", tmpdir);
+    FILE *f = fopen(json_path, "w");
+    assert(f);
+    fputs("[{\"name\":\"Tim\",\"age\":5},{\"name\":\"Lily\",\"age\":2}]", f);
+    fclose(f);
+
     setenv("STORAGE_BASE_PATH", tmpdir, 1);
     assert(storage_init());
 
     animals_init();
     assert(animals_load_from_json());
-    assert(animals_get_count() == 3);
+    assert(animals_get_count() == 2);
 
     const animal_t *a = animals_get(0);
-    assert(a && strcmp(a->name, "Leo") == 0 && a->age == 4);
+    assert(a && strcmp(a->name, "Tim") == 0 && a->age == 5);
 
     a = animals_get(1);
-    assert(a && strcmp(a->name, "Shelly") == 0 && a->age == 10);
+    assert(a && strcmp(a->name, "Lily") == 0 && a->age == 2);
 
-    a = animals_get(2);
-    assert(a && strcmp(a->name, "Fang") == 0 && a->age == 1);
-
-    char dst_path[512];
-    snprintf(dst_path, sizeof(dst_path), "%s/animals.json", tmpdir);
-    unlink(dst_path);
+    unlink(json_path);
     rmdir(tmpdir);
 
     printf("test_animals_load: all tests passed\n");


### PR DESCRIPTION
## Summary
- test loading animals from a json file created in a temporary directory
- ensure storage initialization uses the temp directory

## Testing
- `cd tests && make clean && make`
- `./test_animals && ./test_storage && ./test_logging && ./test_ui && ./test_animals_load`


------
https://chatgpt.com/codex/tasks/task_e_6863aae6f8dc8323a6381b3b38384198