### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential libcjson-dev
+      - name: Build tests
+        run: make -C tests
+      - name: Run tests
+        run: |
+          for bin in tests/test_*; do
+            if [ -x "$bin" ]; then
+              "$bin"
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ESP32 Reptile Dashboard
 
+[![CI](https://github.com/<OWNER>/lizardnova/actions/workflows/ci.yml/badge.svg)](https://github.com/<OWNER>/lizardnova/actions/workflows/ci.yml)
+
 ## Overview
 The project provides a skeleton for a reptile monitoring dashboard running on an ESP32.
 It uses the LVGL graphics library and includes basic components for LCD and touch


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow to build and run unit tests
- show CI status badge in the README

## Testing
- `make -C tests`
- `tests/test_animals && tests/test_storage && tests/test_logging && tests/test_ui && tests/test_animals_load`


------
https://chatgpt.com/codex/tasks/task_e_6863ac9fd21c8323a799087762f74ae8