### PR TITLE
Add docs directory and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ It uses the LVGL graphics library and includes basic components for LCD and touc
 controller drivers. Data about the animals is expected in JSON format and can be
 stored on the device for display.
 
+Additional documentation can be found in the [docs](docs/) directory.
+
 ## Hardware requirements
 - ESP32 development board
 - LCD using an ST7262 controller
@@ -36,24 +38,7 @@ stored on the device for display.
 5. Place any JSON data (e.g. `data/animals.json`) onto the target storage if required.
 
 ## Running unit tests
-
-The repository provides a very small test suite that can be executed on the host
-without ESP‑IDF. Simply change into the `tests` directory and run `make`:
-
-```bash
-cd tests
-make
-```
-
-This will build two executables, `test_animals` and `test_storage`. Run them to
-verify the core components:
-
-```bash
-./test_animals
-./test_storage
-```
-
-Both programs print a confirmation message when the tests pass.
+Host-based unit tests live in `tests/`. Run `make` there to build and run the binaries. Continuous integration executes the same steps as defined in `.github/workflows/ci.yml`. See [docs/testing_ci.md](docs/testing_ci.md) for details.
 
 ## Sample data file
 
@@ -64,23 +49,8 @@ by invoking `animals_load_from_json()`, which internally uses
 
 ## Wiring
 
-Below is a minimal reference for connecting the LCD and touch controllers. See
-the driver headers for additional context.
+For wiring diagrams and driver setup instructions see [docs/driver_setup.md](docs/driver_setup.md).
 
-### ST7262 LCD
+## Contributing
 
-- SPI MOSI &rarr; SDI
-- SPI CLK  &rarr; SCL
-- Chip select driven low while transferring
-- DC pin selects between command (low) and data (high)
-- Optional reset line held low briefly on startup
-
-### GT911 touch controller
-
-- Uses I<sup>2</sup>C
-- SDA connected to the chosen I2C SDA pin
-- SCL connected to the chosen I2C SCL pin
-- The address defaults to `0x5D` but can be changed in software
-
-For complete pinouts refer to the datasheets for the specific LCD and touch
-modules you are using.
+Guidelines for extending the codebase are provided in [docs/extending.md](docs/extending.md).

--- a/docs/driver_setup.md
+++ b/docs/driver_setup.md
@@ -1,0 +1,34 @@
+# Driver Setup and Wiring
+
+This project includes drivers for an ST7262-based LCD and a GT911 touch controller.
+The following diagrams show the recommended connections when using an ESP32 board.
+
+## ST7262 LCD
+
+```
+ESP32   LCD(ST7262)
+------------------
+MOSI -> SDI
+CLK  -> SCL
+CS   -> CS (active low)
+DC   -> D/C
+RST  -> RESET (optional)
+```
+
+`CS` should be held low while data is transferred. `DC` selects command (low) or
+pixel data (high). The reset line may be toggled low on startup if the panel
+requires it.
+
+## GT911 Touch Controller
+
+```
+ESP32   Touch(GT911)
+-------------------
+SDA -> SDA
+SCL -> SCL
+INT -> INT (optional)
+RST -> RESET (optional)
+```
+
+The default I2C address is `0x5D` but it can be changed in software. Consult the
+datasheet for the specific panel for pin locations and voltage requirements.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,20 @@
+# Guidelines for Extending the Codebase
+
+The project follows a component based layout typical for ESP-IDF projects.
+New functionality should be added under the `components/` directory.
+
+1. **Create a component**
+   - Place source files in a new subdirectory under `components`.
+   - Provide an `idf_component.yml` describing the component metadata.
+   - Update any `Kconfig` files if configuration options are required.
+
+2. **Write tests**
+   - Add unit tests in the `tests/` directory.
+   - Include any necessary stubs so tests can run without ESP-IDF.
+
+3. **Keep code portable**
+   - Limit direct hardware access to the driver components.
+   - Use the existing logging utilities for consistency.
+
+Contributions should adhere to the existing coding style and include
+appropriate documentation updates.

--- a/docs/testing_ci.md
+++ b/docs/testing_ci.md
@@ -1,0 +1,19 @@
+# Running Unit Tests and CI
+
+The host based tests reside in the `tests/` directory. They can be built with
+`make` and run directly on a regular Linux system.
+
+```bash
+cd tests
+make            # builds all test binaries
+./test_animals
+./test_animals_load
+./test_logging
+./test_storage
+./test_ui
+```
+
+CI is provided through GitHub Actions. The workflow defined in
+`.github/workflows/ci.yml` installs `libcjson-dev`, builds the tests and executes
+them on each push and pull request. You can trigger the same checks locally with
+the commands above.


### PR DESCRIPTION
## Summary
- add `docs/` folder with driver setup, testing/CI and extension guidelines
- reference new documentation from README

## Testing
- `make -C tests`
- `tests/test_animals`
- `tests/test_animals_load`
- `tests/test_logging`
- `tests/test_storage`
- `tests/test_ui`


------
https://chatgpt.com/codex/tasks/task_e_6863ae321bc8832398988e7f35ca92be