### PR TITLE
Add warn and debug log levels

### DIFF
--- a/components/core/utils/logging.c
+++ b/components/core/utils/logging.c
@@ -19,3 +19,19 @@ void log_error(const char *tag, const char *fmt, ...)
     va_end(args);
 }
 
+void log_warn(const char *tag, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    esp_log_writev(ESP_LOG_WARN, tag, fmt, args);
+    va_end(args);
+}
+
+void log_debug(const char *tag, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    esp_log_writev(ESP_LOG_DEBUG, tag, fmt, args);
+    va_end(args);
+}
+

--- a/components/core/utils/logging.h
+++ b/components/core/utils/logging.h
@@ -10,3 +10,13 @@ void log_info(const char *tag, const char *fmt, ...) __attribute__((format(print
 // Log an error message using the given tag
 void log_error(const char *tag, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 
+// Log a warning message using the given tag
+void log_warn(const char *tag, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+
+// Log a debug message using the given tag
+void log_debug(const char *tag, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+
+// Convenience macros mapping to the above helpers
+#define LOG_WARN(tag, fmt, ...)  log_warn(tag, fmt, ##__VA_ARGS__)
+#define LOG_DEBUG(tag, fmt, ...) log_debug(tag, fmt, ##__VA_ARGS__)
+

--- a/tests/stubs/esp_log.h
+++ b/tests/stubs/esp_log.h
@@ -3,6 +3,8 @@
 
 #define ESP_LOG_INFO 0
 #define ESP_LOG_ERROR 1
+#define ESP_LOG_WARN 2
+#define ESP_LOG_DEBUG 3
 
 typedef int esp_log_level_t;
 

--- a/tests/test_logging.c
+++ b/tests/test_logging.c
@@ -12,6 +12,12 @@ int main(void)
     log_error("TEST", "str %s %d", "hi", 3);
     assert(strcmp(esp_log_last_buf, "str hi 3") == 0);
 
+    LOG_WARN("TEST", "warn %d", 7);
+    assert(strcmp(esp_log_last_buf, "warn 7") == 0);
+
+    LOG_DEBUG("TEST", "dbg %s", "ok");
+    assert(strcmp(esp_log_last_buf, "dbg ok") == 0);
+
     printf("test_logging: all tests passed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
- extend logging API with warning and debug helpers
- handle new levels in implementation and stub
- validate new macros with unit test

## Testing
- `make` in `tests`
- `./test_logging`
- `./test_animals`
- `./test_storage`
- `./test_ui`
- `./test_animals_load`
- `./test_agents`


------
https://chatgpt.com/codex/tasks/task_e_6863b2cf7e588323a2361ea29f4e5608