### PR TITLE
Add AI extensions doc

### DIFF
--- a/docs/ai_extensions.md
+++ b/docs/ai_extensions.md
@@ -1,0 +1,40 @@
+# AI Extensions
+
+This project focuses on local monitoring but it can be expanded with AI features.
+The sections below outline possible integrations and the modules they require.
+
+## Cloud APIs
+
+- Connect to external machine learning services for image or data analysis.
+- Sync local readings to a remote endpoint for long term storage.
+- Fetch updates from a cloud dashboard via REST or MQTT.
+
+Required modules:
+- `cloud_client` providing HTTP or MQTT wrappers.
+- `token_store` for managing credentials.
+
+## Voice Assistant Hooks
+
+- Enable voice control through a companion device or smart speaker.
+- Handle commands such as "show humidity" or "set lighting schedule".
+
+Required modules:
+- `voice_adapter` to process audio commands.
+- Updates to the existing `assistant` agent to route voice intents.
+
+## Advanced Analytics
+
+- Run on-device inference for predictive alerts.
+- Combine historical data to suggest care instructions.
+
+Required modules:
+- `analytics_engine` for loading models and generating results.
+- Extensions to `storage` for logging training data.
+
+## Data Flow Overview
+
+1. Sensors publish data to the core modules.
+2. The analytics engine or cloud client processes the readings.
+3. Results are routed back into the UI and voice assistant.
+4. Processed data may optionally sync to a cloud service.
+


### PR DESCRIPTION
## Summary
- document AI extension ideas including cloud APIs, voice assistant hooks and analytics

## Testing
- `make -C tests`
- `tests/test_animals && tests/test_storage && tests/test_logging && tests/test_ui && tests/test_animals_load && tests/test_agents`

------
https://chatgpt.com/codex/tasks/task_e_6863b43e555c8323a02940cf612856e4