### PR TITLE
Add ESP-IDF build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,14 @@ jobs:
               "$bin"
             fi
           done
+
+  idf-build:
+    runs-on: ubuntu-latest
+    container:
+      image: espressif/idf:latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Build firmware
+        run: idf.py build


### PR DESCRIPTION
## Summary
- extend CI workflow to build firmware using esp-idf Docker image

## Testing
- `make -C tests`
- ran unit tests

------
https://chatgpt.com/codex/tasks/task_e_6863c499529883239e57ac9b8d12f97f