### PR TITLE
Fix component manifest syntax

### DIFF
--- a/components/core/utils/idf_component.yml
+++ b/components/core/utils/idf_component.yml
@@ -1,5 +1,6 @@
 version: "0.1.0"
 description: "Utility helpers"
 dependencies:
-  idf: ">=5.0"
-  log: "*"
+  idf:
+    version: ">=5.0"
+    components: [log]

--- a/components/drivers/touch_gt911/idf_component.yml
+++ b/components/drivers/touch_gt911/idf_component.yml
@@ -1,7 +1,8 @@
 version: "0.1.0"
 description: "GT911 touch driver"
 dependencies:
-  idf: ">=5.0"
-  driver: "*"
+  idf:
+    version: ">=5.0"
+    components: [driver]
   utils: "*"
   lvgl: "*"


### PR DESCRIPTION
## Summary
- tidy up IDF component manifests
- use list form for IDF dependencies

## Testing
- `idf.py set-target esp32s3`
- `make -C tests` *(fails: fatal error: cJSON.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6863ce4622b48323918dac08cdac95ee