### PR TITLE
Add libcjson-dev note for local tests

### DIFF
--- a/docs/testing_ci.md
+++ b/docs/testing_ci.md
@@ -1,7 +1,15 @@
 # Running Unit Tests and CI
 
 The host based tests reside in the `tests/` directory. They can be built with
-`make` and run directly on a regular Linux system.
+`make` and run directly on a regular Linux system. The makefile links against
+the system `cjson` library, so you need the development package installed
+before invoking `make`.
+
+For Debian based systems you can install the dependency with:
+
+```bash
+sudo apt-get install libcjson-dev
+```
 
 ```bash
 cd tests


### PR DESCRIPTION
## Summary
- document that `libcjson-dev` is required when running `make -C tests`

## Testing
- `make -C tests`
- run all test binaries

------
https://chatgpt.com/codex/tasks/task_e_6863d20a00688323afa18ab29538203e