### PR TITLE
Fix component manifest format

### DIFF
--- a/components/core/utils/idf_component.yml
+++ b/components/core/utils/idf_component.yml
@@ -1,6 +1,6 @@
 version: "0.1.0"
 description: "Utility helpers"
 dependencies:
-  idf:
-    version: ">=5.0"
-    components: [log]
+  idf: ">=5.0"
+  idf_components:
+    - log

--- a/components/drivers/touch_gt911/idf_component.yml
+++ b/components/drivers/touch_gt911/idf_component.yml
@@ -1,8 +1,8 @@
 version: "0.1.0"
 description: "GT911 touch driver"
 dependencies:
-  idf:
-    version: ">=5.0"
-    components: [driver]
+  idf: ">=5.0"
+  idf_components:
+    - driver
   utils: "*"
   lvgl: "*"


### PR DESCRIPTION
## Summary
- correct idf_component.yml dependency format for utils
- correct idf_component.yml dependency format for GT911 driver
- keep other manifests unchanged

## Testing
- `idf.py fullclean && idf.py build` *(fails: `idf.py` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863d5709ec48323a914f4132f290abf