### PR TITLE
Fix IDF component dependency syntax

### DIFF
--- a/components/core/utils/idf_component.yml
+++ b/components/core/utils/idf_component.yml
@@ -3,4 +3,4 @@ description: "Utility helpers"
 dependencies:
   idf: ">=5.0"
   idf_components:
-    - log
+    log: "*"

--- a/components/drivers/touch_gt911/idf_component.yml
+++ b/components/drivers/touch_gt911/idf_component.yml
@@ -3,6 +3,6 @@ description: "GT911 touch driver"
 dependencies:
   idf: ">=5.0"
   idf_components:
-    - driver
+    driver: "*"
   utils: "*"
   lvgl: "*"


### PR DESCRIPTION
## Summary
- fix syntax in `idf_component.yml` files so `idf_components` is a mapping
- run unit tests
- attempt `idf.py fullclean && idf.py build`

## Testing
- `make -C tests`
- ran test binaries
- `idf.py fullclean && idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863de092b388323883b443c4c04678f