### PR TITLE
Remove legacy IDF deps

### DIFF
--- a/components/agents/autoconfig/CMakeLists.txt
+++ b/components/agents/autoconfig/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "autoconfig.c"
     INCLUDE_DIRS "."
-    REQUIRES utils storage
+    REQUIRES utils storage json
 )

--- a/components/agents/autoconfig/idf_component.yml
+++ b/components/agents/autoconfig/idf_component.yml
@@ -4,4 +4,3 @@ dependencies:
   idf: ">=5.0"
   utils: "*"
   storage: "*"
-  cJSON: "*"

--- a/components/core/animals/CMakeLists.txt
+++ b/components/core/animals/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
     SRCS "animals.c"
     INCLUDE_DIRS "."
+    REQUIRES storage utils json
 )

--- a/components/core/animals/idf_component.yml
+++ b/components/core/animals/idf_component.yml
@@ -3,4 +3,3 @@ description: "Animal data management"
 dependencies:
   idf: ">=5.0"
   storage: "*"
-  cJSON: "*"

--- a/components/core/utils/idf_component.yml
+++ b/components/core/utils/idf_component.yml
@@ -2,4 +2,3 @@ version: "0.1.0"
 description: "Utility helpers"
 dependencies:
   idf: ">=5.0"
-  log: "*"

--- a/components/drivers/lcd_st7262/idf_component.yml
+++ b/components/drivers/lcd_st7262/idf_component.yml
@@ -2,6 +2,5 @@ version: "0.1.0"
 description: "ST7262 LCD driver"
 dependencies:
   idf: ">=5.0"
-  driver: "*"
   lvgl: "*"
   utils: "*"

--- a/components/drivers/touch_gt911/idf_component.yml
+++ b/components/drivers/touch_gt911/idf_component.yml
@@ -2,6 +2,5 @@ version: "0.1.0"
 description: "GT911 touch driver"
 dependencies:
   idf: ">=5.0"
-  driver: "*"
   utils: "*"
   lvgl: "*"


### PR DESCRIPTION
## Summary
- cleanup manifests to avoid explicit IDF component references
- link animals and autoconfig components to IDF libs via CMake

## Testing
- `make -C tests`
- `for bin in tests/test_*; do if [ -x "$bin" ]; then "$bin"; fi; done`
- `idf.py build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6864edd43c448323953a57a755b33f9f