### PR TITLE
Fix CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESP32 Reptile Dashboard
 
-[![CI](https://github.com/<OWNER>/lizardnova/actions/workflows/ci.yml/badge.svg)](https://github.com/<OWNER>/lizardnova/actions/workflows/ci.yml)
+[![CI](https://github.com/novaeco/lizardnova/actions/workflows/ci.yml/badge.svg)](https://github.com/novaeco/lizardnova/actions/workflows/ci.yml)
 
 ## Overview
 The project provides a skeleton for a reptile monitoring dashboard running on an ESP32.


### PR DESCRIPTION
## Summary
- update owner in CI badge so it renders correctly

## Testing
- `cd tests && make`
- `./test_animals && ./test_animals_load && ./test_logging && ./test_storage && ./test_ui && ./test_agents && ./test_autoconfig && ./test_diagnostic`

------
https://chatgpt.com/codex/tasks/task_e_6864f574c6b88323845488b85836e70a