### PR TITLE
Clarify libcjson requirement

### DIFF
--- a/docs/testing_ci.md
+++ b/docs/testing_ci.md
@@ -1,9 +1,6 @@
 # Running Unit Tests and CI
 
-The host based tests reside in the `tests/` directory. They can be built with
-`make` and run directly on a regular Linux system. The makefile links against
-the system `cjson` library, so you need the development package installed
-before invoking `make`.
+The host based tests reside in the `tests/` directory. They can be built with `make` and run directly on a regular Linux system. The makefile links against the system `cjson` library, so you need the `libcjson-dev` development package installed before invoking `make`.
 
 For Debian based systems you can install the dependency with:
 


### PR DESCRIPTION
## Summary
- clarify that the host tests depend on `libcjson-dev` in docs

## Testing
- `make -C tests`
- `tests/test_animals && tests/test_animals_load && tests/test_logging && tests/test_storage && tests/test_ui`
- `tests/test_agents && tests/test_autoconfig && tests/test_diagnostic`


------
https://chatgpt.com/codex/tasks/task_e_68650053867c83238701b4ceeb5bd800