### PR TITLE
Ensure FreeRTOS linked via REQUIRES

### DIFF
--- a/components/drivers/lcd_st7262/CMakeLists.txt
+++ b/components/drivers/lcd_st7262/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "lcd_st7262.c"
     INCLUDE_DIRS "."
-    REQUIRES lvgl utils
+    REQUIRES lvgl utils driver freertos
 )

--- a/components/drivers/touch_gt911/CMakeLists.txt
+++ b/components/drivers/touch_gt911/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "gt911.c"
     INCLUDE_DIRS "."
-    REQUIRES driver utils lvgl
+    REQUIRES driver utils lvgl freertos
 )

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "main.c"
     INCLUDE_DIRS "." "../components"
-    REQUIRES animals storage ui utils lcd_st7262 touch_gt911
+    REQUIRES animals storage ui utils lcd_st7262 touch_gt911 freertos
 )


### PR DESCRIPTION
## Summary
- link FreeRTOS explicitly from main and driver components
- no `idf_components:` fields existed to remove

## Testing
- `make -C tests`
- executed unit tests

------
https://chatgpt.com/codex/tasks/task_e_686501dfe7c88323a2c2653a7b29aeef