### PR TITLE
Fix test stub warnings

### DIFF
--- a/tests/stubs/driver/gpio.h
+++ b/tests/stubs/driver/gpio.h
@@ -3,5 +3,5 @@ typedef int gpio_num_t;
 #define GPIO_PULLUP_ENABLE 0
 #define GPIO_MODE_OUTPUT 0
 typedef struct {int mode; unsigned long long pin_bit_mask;} gpio_config_t;
-static inline int gpio_config(const gpio_config_t *cfg) { return 0; }
-static inline int gpio_set_level(gpio_num_t num, int level) { return 0; }
+static inline int gpio_config(const gpio_config_t *cfg) { (void)cfg; return 0; }
+static inline int gpio_set_level(gpio_num_t num, int level) { (void)num; (void)level; return 0; }

--- a/tests/stubs/driver/i2c.h
+++ b/tests/stubs/driver/i2c.h
@@ -3,13 +3,28 @@
 typedef int i2c_port_t;
 typedef int i2c_cmd_handle_t;
 typedef struct {int mode; int sda_io_num; int scl_io_num; int sda_pullup_en; int scl_pullup_en; struct {int clk_speed;} master; int clk_flags;} i2c_config_t;
-static inline int i2c_param_config(i2c_port_t port, const i2c_config_t *conf) { return 0; }
-static inline int i2c_driver_install(i2c_port_t port, int mode, int rx, int tx, int flags) { return 0; }
+static inline int i2c_param_config(i2c_port_t port, const i2c_config_t *conf) {
+    (void)port;
+    (void)conf;
+    return 0;
+}
+static inline int i2c_driver_install(i2c_port_t port, int mode, int rx, int tx, int flags) {
+    (void)port; (void)mode; (void)rx; (void)tx; (void)flags;
+    return 0;
+}
 static inline i2c_cmd_handle_t i2c_cmd_link_create(void) { return 0; }
 static inline void i2c_cmd_link_delete(i2c_cmd_handle_t cmd) { (void)cmd; }
-static inline int i2c_master_start(i2c_cmd_handle_t cmd) { return 0; }
-static inline int i2c_master_write_byte(i2c_cmd_handle_t cmd, int data, int ack) { return 0; }
-static inline int i2c_master_write(i2c_cmd_handle_t cmd, const void *buf, int len, int ack) { return 0; }
-static inline int i2c_master_read(i2c_cmd_handle_t cmd, void *buf, int len, int last_nack) { memset(buf,0,len); return 0; }
-static inline int i2c_master_stop(i2c_cmd_handle_t cmd) { return 0; }
-static inline int i2c_master_cmd_begin(i2c_port_t port, i2c_cmd_handle_t cmd, int ticks) { return 0; }
+static inline int i2c_master_start(i2c_cmd_handle_t cmd) { (void)cmd; return 0; }
+static inline int i2c_master_write_byte(i2c_cmd_handle_t cmd, int data, int ack) {
+    (void)cmd; (void)data; (void)ack; return 0;
+}
+static inline int i2c_master_write(i2c_cmd_handle_t cmd, const void *buf, int len, int ack) {
+    (void)cmd; (void)buf; (void)len; (void)ack; return 0;
+}
+static inline int i2c_master_read(i2c_cmd_handle_t cmd, void *buf, int len, int last_nack) {
+    (void)cmd; (void)last_nack; memset(buf,0,len); return 0;
+}
+static inline int i2c_master_stop(i2c_cmd_handle_t cmd) { (void)cmd; return 0; }
+static inline int i2c_master_cmd_begin(i2c_port_t port, i2c_cmd_handle_t cmd, int ticks) {
+    (void)port; (void)cmd; (void)ticks; return 0;
+}


### PR DESCRIPTION
## Summary
- update driver stub headers to mark unused params

## Testing
- `make`
- run all test binaries

------
https://chatgpt.com/codex/tasks/task_e_68651a67969c8323b6b24e4cc4585c84