### PR TITLE
Add HTU21 sensor driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ Reptile Manager Pro is a basic example using the LVGL graphics library on the ES
 - ES8311 audio codec (supported by the board)
 - External USB‑to‑UART adapter for flashing
 
+### Sensor Wiring
+Connect an HTU21 (or compatible) temperature and humidity sensor to the
+on‑board I2C bus:
+
+- SDA -> **GPIO40**
+- SCL -> **GPIO41**
+- VCC -> 3.3&nbsp;V
+- GND -> GND
+
+Other I2C sensors may be used if they share the same pins.
+
 ## Build and Flash Instructions
 1. Install **ESP-IDF 5.0** or newer. Follow the [ESP-IDF setup guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/get-started/).
 2. From the project directory, set the target and build the firmware:

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,6 @@
-idf_component_register(SRCS "main.cpp" 
-                    "sensors.cpp" 
-                    "storage.cpp" 
+idf_component_register(SRCS "main.cpp"
+                    "sensors.cpp"
+                    "storage.cpp"
                     "ui.cpp"
-                    INCLUDE_DIRS ".")
+                    INCLUDE_DIRS "."
+                    REQUIRES i2c_devices)

--- a/main/sensors.cpp
+++ b/main/sensors.cpp
@@ -3,28 +3,25 @@
 #include "freertos/task.h"
 #include "esp_log.h"
 #include "esp_system.h"
+#include "bsp_i2c.h"
+#include "htu21.h"
 #include <stdio.h>
 
 static const char *TAG = "Sensors";
 
 sensor_data_t g_sensor_data = {0};
 
-static float read_temperature()
-{
-    return 20.0f + (float)(esp_random() % 1000) / 100.0f;
-}
-
-static float read_humidity()
-{
-    return 40.0f + (float)(esp_random() % 600) / 10.0f;
-}
-
 extern "C" void sensor_task(void *arg)
 {
     (void)arg;
+
+    // Initialize I2C bus and HTU21 sensor
+    bsp_i2c_init(I2C_NUM_0, 400000);
+    htu21_init();
+
     while (1) {
-        g_sensor_data.temperature = read_temperature();
-        g_sensor_data.humidity = read_humidity();
+        g_sensor_data.temperature = htu21_get_temp();
+        g_sensor_data.humidity = htu21_get_humid();
         ESP_LOGI(TAG, "Temp: %.2f C, Humidity: %.2f %%", g_sensor_data.temperature, g_sensor_data.humidity);
         FILE *f = fopen("/spiffs/sensor.log", "a");
         if (f) {


### PR DESCRIPTION
## Summary
- read temperature/humidity via HTU21 sensor
- depend on i2c_devices component
- document wiring for the sensor

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fe1fca748323913835b0720888ca