### PR TITLE
Add minimal ESP-IDF project structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.5)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(lizardnova)

--- a/components/backlight/CMakeLists.txt
+++ b/components/backlight/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "backlight.c" INCLUDE_DIRS "include")

--- a/components/backlight/backlight.c
+++ b/components/backlight/backlight.c
@@ -1,0 +1,8 @@
+#include "backlight.h"
+#include "esp_log.h"
+
+void backlight_init(void)
+{
+    // Placeholder initialization
+    ESP_LOGI("backlight", "Initializing backlight");
+}

--- a/components/backlight/include/backlight.h
+++ b/components/backlight/include/backlight.h
@@ -1,0 +1,2 @@
+#pragma once
+void backlight_init(void);

--- a/components/buttons/CMakeLists.txt
+++ b/components/buttons/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "buttons.c" INCLUDE_DIRS "include")

--- a/components/buttons/buttons.c
+++ b/components/buttons/buttons.c
@@ -1,0 +1,8 @@
+#include "buttons.h"
+#include "esp_log.h"
+
+void buttons_init(void)
+{
+    // Placeholder initialization
+    ESP_LOGI("buttons", "Initializing buttons");
+}

--- a/components/buttons/include/buttons.h
+++ b/components/buttons/include/buttons.h
@@ -1,0 +1,2 @@
+#pragma once
+void buttons_init(void);

--- a/components/display/CMakeLists.txt
+++ b/components/display/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "display.c" INCLUDE_DIRS "include")

--- a/components/display/display.c
+++ b/components/display/display.c
@@ -1,0 +1,8 @@
+#include "display.h"
+#include "esp_log.h"
+
+void display_init(void)
+{
+    // Placeholder initialization
+    ESP_LOGI("display", "Initializing display");
+}

--- a/components/display/include/display.h
+++ b/components/display/include/display.h
@@ -1,0 +1,2 @@
+#pragma once
+void display_init(void);

--- a/components/keyboard/CMakeLists.txt
+++ b/components/keyboard/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "keyboard.c" INCLUDE_DIRS "include")

--- a/components/keyboard/include/keyboard.h
+++ b/components/keyboard/include/keyboard.h
@@ -1,0 +1,2 @@
+#pragma once
+void keyboard_init(void);

--- a/components/keyboard/keyboard.c
+++ b/components/keyboard/keyboard.c
@@ -1,0 +1,8 @@
+#include "keyboard.h"
+#include "esp_log.h"
+
+void keyboard_init(void)
+{
+    // Placeholder initialization
+    ESP_LOGI("keyboard", "Initializing keyboard");
+}

--- a/components/network/CMakeLists.txt
+++ b/components/network/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "network.c" INCLUDE_DIRS "include")

--- a/components/network/include/network.h
+++ b/components/network/include/network.h
@@ -1,0 +1,2 @@
+#pragma once
+void network_init(void);

--- a/components/network/network.c
+++ b/components/network/network.c
@@ -1,0 +1,8 @@
+#include "network.h"
+#include "esp_log.h"
+
+void network_init(void)
+{
+    // Placeholder initialization
+    ESP_LOGI("network", "Initializing network");
+}

--- a/components/power/CMakeLists.txt
+++ b/components/power/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "power.c" INCLUDE_DIRS "include")

--- a/components/power/include/power.h
+++ b/components/power/include/power.h
@@ -1,0 +1,2 @@
+#pragma once
+void power_init(void);

--- a/components/power/power.c
+++ b/components/power/power.c
@@ -1,0 +1,8 @@
+#include "power.h"
+#include "esp_log.h"
+
+void power_init(void)
+{
+    // Placeholder initialization
+    ESP_LOGI("power", "Initializing power");
+}

--- a/components/storage_sd/CMakeLists.txt
+++ b/components/storage_sd/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "storage_sd.c" INCLUDE_DIRS "include")

--- a/components/storage_sd/include/storage_sd.h
+++ b/components/storage_sd/include/storage_sd.h
@@ -1,0 +1,2 @@
+#pragma once
+void storage_sd_init(void);

--- a/components/storage_sd/storage_sd.c
+++ b/components/storage_sd/storage_sd.c
@@ -1,0 +1,8 @@
+#include "storage_sd.h"
+#include "esp_log.h"
+
+void storage_sd_init(void)
+{
+    // Placeholder initialization
+    ESP_LOGI("storage_sd", "Initializing storage_sd");
+}

--- a/components/touch/CMakeLists.txt
+++ b/components/touch/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "touch.c" INCLUDE_DIRS "include")

--- a/components/touch/include/touch.h
+++ b/components/touch/include/touch.h
@@ -1,0 +1,2 @@
+#pragma once
+void touch_init(void);

--- a/components/touch/touch.c
+++ b/components/touch/touch.c
@@ -1,0 +1,8 @@
+#include "touch.h"
+#include "esp_log.h"
+
+void touch_init(void)
+{
+    // Placeholder initialization
+    ESP_LOGI("touch", "Initializing touch");
+}

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -1,0 +1,18 @@
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+
+static const char *TAG = "app_main";
+
+static void hello_task(void *pvParameter)
+{
+    while (1) {
+        ESP_LOGI(TAG, "Hello from LizardNova!");
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}
+
+void app_main(void)
+{
+    xTaskCreate(hello_task, "hello_task", 2048, NULL, 5, NULL);
+}

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,0 +1,1 @@
+# Default configuration options


### PR DESCRIPTION
## Summary
- add root CMake project definition
- provide FreeRTOS example task in `app_main`
- create placeholder components for future features
- add default SDK config

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68740c8cae5483239b9a1886f3d84da7