### PR TITLE
Propagate init errors

### DIFF
--- a/components/backlight/backlight.c
+++ b/components/backlight/backlight.c
@@ -6,7 +6,7 @@
 
 static ledc_channel_config_t ledc_channel;
 
-void backlight_init(void)
+esp_err_t backlight_init(void)
 {
     ledc_timer_config_t ledc_timer = {
         .speed_mode       = LEDC_LOW_SPEED_MODE,
@@ -15,7 +15,11 @@ void backlight_init(void)
         .freq_hz          = 1000,
         .clk_cfg          = LEDC_AUTO_CLK,
     };
-    ledc_timer_config(&ledc_timer);
+    esp_err_t err = ledc_timer_config(&ledc_timer);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "ledc_timer_config failed: %s", esp_err_to_name(err));
+        return err;
+    }
 
     ledc_channel.gpio_num   = 5;
     ledc_channel.speed_mode = LEDC_LOW_SPEED_MODE;
@@ -23,9 +27,14 @@ void backlight_init(void)
     ledc_channel.timer_sel  = LEDC_TIMER_0;
     ledc_channel.duty       = 0;
     ledc_channel.hpoint     = 0;
-    ledc_channel_config(&ledc_channel);
+    err = ledc_channel_config(&ledc_channel);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "ledc_channel_config failed: %s", esp_err_to_name(err));
+        return err;
+    }
 
     ESP_LOGI(TAG, "Backlight PWM initialized");
+    return ESP_OK;
 }
 
 void backlight_set(uint8_t level)

--- a/components/backlight/include/backlight.h
+++ b/components/backlight/include/backlight.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "esp_err.h"
+
 /** Initialize PWM for LCD backlight */
-void backlight_init(void);
+esp_err_t backlight_init(void);
 
 /** Set backlight level (0-255) */
 void backlight_set(uint8_t level);

--- a/components/buttons/buttons.c
+++ b/components/buttons/buttons.c
@@ -1,8 +1,9 @@
 #include "buttons.h"
 #include "esp_log.h"
 
-void buttons_init(void)
+esp_err_t buttons_init(void)
 {
     // Placeholder initialization
     ESP_LOGI("buttons", "Initializing buttons");
+    return ESP_OK;
 }

--- a/components/buttons/include/buttons.h
+++ b/components/buttons/include/buttons.h
@@ -1,2 +1,4 @@
 #pragma once
-void buttons_init(void);
+#include "esp_err.h"
+
+esp_err_t buttons_init(void);

--- a/components/display/display.c
+++ b/components/display/display.c
@@ -39,7 +39,7 @@ static void disp_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *co
     lv_disp_flush_ready(drv);
 }
 
-void display_init(void)
+esp_err_t display_init(void)
 {
     lv_init();
 
@@ -50,7 +50,11 @@ void display_init(void)
         .quadwp_io_num = -1,
         .quadhd_io_num = -1,
     };
-    spi_bus_initialize(SPI2_HOST, &buscfg, SPI_DMA_CH_AUTO);
+    esp_err_t err = spi_bus_initialize(SPI2_HOST, &buscfg, SPI_DMA_CH_AUTO);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to init SPI bus: %s", esp_err_to_name(err));
+        return err;
+    }
 
     spi_device_interface_config_t devcfg = {
         .clock_speed_hz = 40 * 1000 * 1000,
@@ -58,7 +62,11 @@ void display_init(void)
         .spics_io_num = 10,
         .queue_size = 7,
     };
-    spi_bus_add_device(SPI2_HOST, &devcfg, &st7789_handle);
+    err = spi_bus_add_device(SPI2_HOST, &devcfg, &st7789_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to add SPI device: %s", esp_err_to_name(err));
+        return err;
+    }
 
     ESP_LOGI(TAG, "ST7789 initialized");
 
@@ -69,6 +77,7 @@ void display_init(void)
     disp_drv.hor_res = 240;
     disp_drv.ver_res = 320;
     lv_disp_drv_register(&disp_drv);
+    return ESP_OK;
 }
 
 void display_update(void)

--- a/components/display/include/display.h
+++ b/components/display/include/display.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "esp_err.h"
+
 /** Initialize ST7789 display and LVGL */
-void display_init(void);
+esp_err_t display_init(void);
 
 /** Periodically call from main loop to update LVGL */
 void display_update(void);

--- a/components/keyboard/include/keyboard.h
+++ b/components/keyboard/include/keyboard.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "esp_err.h"
+
 /** Initialize matrix keyboard scanning */
-void keyboard_init(void);
+esp_err_t keyboard_init(void);
 
 /** Retrieve latest key state as bitmask */
 uint16_t keyboard_get_state(void);

--- a/components/network/include/network.h
+++ b/components/network/include/network.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "esp_err.h"
+
 /** Initialize Wi-Fi 6 and BLE subsystems */
-void network_init(void);
+esp_err_t network_init(void);
 
 /** Periodically update network status on LVGL display */
 void network_update(void);

--- a/components/network/network.c
+++ b/components/network/network.c
@@ -10,26 +10,63 @@
 
 static lv_obj_t *status_label;
 
-void network_init(void)
+esp_err_t network_init(void)
 {
-    nvs_flash_init();
-    esp_netif_init();
-    esp_event_loop_create_default();
+    esp_err_t err = nvs_flash_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "nvs_flash_init failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = esp_netif_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_netif_init failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = esp_event_loop_create_default();
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "esp_event_loop_create_default failed: %s", esp_err_to_name(err));
+        return err;
+    }
 
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-    esp_wifi_init(&cfg);
-    esp_wifi_set_mode(WIFI_MODE_STA);
-    esp_wifi_start();
+    err = esp_wifi_init(&cfg);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_wifi_init failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = esp_wifi_set_mode(WIFI_MODE_STA);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_wifi_set_mode failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = esp_wifi_start();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_wifi_start failed: %s", esp_err_to_name(err));
+        return err;
+    }
 
-    esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
+    err = esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "bt mem release failed: %s", esp_err_to_name(err));
+        return err;
+    }
     esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-    esp_bt_controller_init(&bt_cfg);
-    esp_bt_controller_enable(ESP_BT_MODE_BLE);
+    err = esp_bt_controller_init(&bt_cfg);
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "bt controller init failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = esp_bt_controller_enable(ESP_BT_MODE_BLE);
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "bt controller enable failed: %s", esp_err_to_name(err));
+        return err;
+    }
 
     status_label = lv_label_create(lv_scr_act());
     lv_label_set_text(status_label, "Wi-Fi/BLE starting...");
 
     ESP_LOGI(TAG, "Wi-Fi 6 and BLE initialized");
+    return ESP_OK;
 }
 
 void network_update(void)

--- a/components/power/include/power.h
+++ b/components/power/include/power.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "esp_err.h"
+
 /** Initialize power management */
-void power_init(void);
+esp_err_t power_init(void);
 
 /** Switch CPU to high performance mode */
 void power_high_performance(void);

--- a/components/power/power.c
+++ b/components/power/power.c
@@ -6,10 +6,15 @@
 
 static esp_pm_lock_handle_t s_performance_lock;
 
-void power_init(void)
+esp_err_t power_init(void)
 {
-    esp_pm_lock_create(ESP_PM_CPU_FREQ_MAX, 0, "perf", &s_performance_lock);
+    esp_err_t err = esp_pm_lock_create(ESP_PM_CPU_FREQ_MAX, 0, "perf", &s_performance_lock);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_pm_lock_create failed: %s", esp_err_to_name(err));
+        return err;
+    }
     ESP_LOGI(TAG, "Power management initialized");
+    return ESP_OK;
 }
 
 void power_high_performance(void)

--- a/components/storage_sd/include/storage_sd.h
+++ b/components/storage_sd/include/storage_sd.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "esp_err.h"
+
 /** Mount microSD card and make resources available */
-void storage_sd_init(void);
+esp_err_t storage_sd_init(void);
 
 /** Load a file into memory from the SD card */
 void *storage_sd_load(const char *path, size_t *size);

--- a/components/storage_sd/storage_sd.c
+++ b/components/storage_sd/storage_sd.c
@@ -11,7 +11,7 @@
 
 static sdmmc_card_t *sdcard;
 
-void storage_sd_init(void)
+esp_err_t storage_sd_init(void)
 {
     sdmmc_host_t host = SDMMC_HOST_DEFAULT();
     sdmmc_slot_config_t slot_config = SDMMC_SLOT_CONFIG_DEFAULT();
@@ -21,8 +21,13 @@ void storage_sd_init(void)
         .max_files = 5,
     };
 
-    esp_vfs_fat_sdmmc_mount("/sdcard", &host, &slot_config, &mount_config, &sdcard);
+    esp_err_t err = esp_vfs_fat_sdmmc_mount("/sdcard", &host, &slot_config, &mount_config, &sdcard);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to mount SD card: %s", esp_err_to_name(err));
+        return err;
+    }
     ESP_LOGI(TAG, "SD card mounted");
+    return ESP_OK;
 }
 
 void *storage_sd_load(const char *path, size_t *size)

--- a/components/touch/include/touch.h
+++ b/components/touch/include/touch.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "esp_err.h"
+
 /** Initialize optional touch controller */
-void touch_init(void);
+esp_err_t touch_init(void);
 
 /** Read touch coordinates, returns true if touched */
 bool touch_read(uint16_t *x, uint16_t *y);

--- a/components/touch/touch.c
+++ b/components/touch/touch.c
@@ -6,7 +6,7 @@
 
 static bool has_touch = false;
 
-void touch_init(void)
+esp_err_t touch_init(void)
 {
     i2c_config_t conf = {
         .mode = I2C_MODE_MASTER,
@@ -16,11 +16,20 @@ void touch_init(void)
         .scl_pullup_en = GPIO_PULLUP_ENABLE,
         .master.clk_speed = 400000,
     };
-    i2c_param_config(I2C_NUM_0, &conf);
-    i2c_driver_install(I2C_NUM_0, conf.mode, 0, 0, 0);
+    esp_err_t err = i2c_param_config(I2C_NUM_0, &conf);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "i2c_param_config failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = i2c_driver_install(I2C_NUM_0, conf.mode, 0, 0, 0);
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "i2c_driver_install failed: %s", esp_err_to_name(err));
+        return err;
+    }
 
     has_touch = true;
     ESP_LOGI(TAG, "Touch controller initialized");
+    return ESP_OK;
 }
 
 bool touch_read(uint16_t *x, uint16_t *y)

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -21,13 +21,43 @@ static void hello_task(void *pvParameter)
 
 void app_main(void)
 {
-    power_init();
-    backlight_init();
-    display_init();
-    keyboard_init();
-    touch_init();
-    storage_sd_init();
-    network_init();
+    esp_err_t err;
+
+    err = power_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "power_init failed: %s", esp_err_to_name(err));
+        return;
+    }
+    err = backlight_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "backlight_init failed: %s", esp_err_to_name(err));
+        return;
+    }
+    err = display_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "display_init failed: %s", esp_err_to_name(err));
+        return;
+    }
+    err = keyboard_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "keyboard_init failed: %s", esp_err_to_name(err));
+        return;
+    }
+    err = touch_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "touch_init failed: %s", esp_err_to_name(err));
+        return;
+    }
+    err = storage_sd_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "storage_sd_init failed: %s", esp_err_to_name(err));
+        return;
+    }
+    err = network_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "network_init failed: %s", esp_err_to_name(err));
+        return;
+    }
 
     backlight_set(128);
     xTaskCreate(hello_task, "hello_task", 2048, NULL, 5, NULL);


### PR DESCRIPTION
## Summary
- make all component init functions return `esp_err_t`
- add error checking and logging throughout initialization
- update `app_main` to stop on initialization failure

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687414e701788323ad036b6faa815e4c