### PR TITLE
Add configurable display settings and DMA flush

### DIFF
--- a/components/display/display.c
+++ b/components/display/display.c
@@ -9,7 +9,8 @@
 static spi_device_handle_t st7789_handle;
 static lv_disp_drv_t disp_drv;
 static lv_disp_draw_buf_t draw_buf;
-static lv_color_t buf[320 * 10]; /* 10 lines buffer */
+static lv_color_t buf1[320 * 10]; /* 10 lines buffer */
+static lv_color_t buf2[320 * 10];
 
 static void st7789_send_cmd(uint8_t cmd)
 {
@@ -33,13 +34,29 @@ static void st7789_send_data(const void *data, size_t len)
 
 static void disp_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p)
 {
-    /* In a real driver the address window would be set here */
+    uint8_t data[4];
+    st7789_send_cmd(0x2A); /* Column address set */
+    data[0] = area->x1 >> 8;
+    data[1] = area->x1 & 0xFF;
+    data[2] = area->x2 >> 8;
+    data[3] = area->x2 & 0xFF;
+    st7789_send_data(data, 4);
+
+    st7789_send_cmd(0x2B); /* Row address set */
+    data[0] = area->y1 >> 8;
+    data[1] = area->y1 & 0xFF;
+    data[2] = area->y2 >> 8;
+    data[3] = area->y2 & 0xFF;
+    st7789_send_data(data, 4);
+
+    st7789_send_cmd(0x2C); /* Memory write */
+
     size_t len = (area->x2 - area->x1 + 1) * (area->y2 - area->y1 + 1) * sizeof(lv_color_t);
     st7789_send_data(color_p, len);
     lv_disp_flush_ready(drv);
 }
 
-esp_err_t display_init(void)
+esp_err_t display_init(const display_config_t *config)
 {
     lv_init();
 
@@ -68,14 +85,32 @@ esp_err_t display_init(void)
         return err;
     }
 
+    uint8_t param;
+    st7789_send_cmd(0x3A); /* COLMOD */
+    param = (config && config->color_format == DISPLAY_COLOR_FORMAT_RGB666) ? 0x66 : 0x55;
+    st7789_send_data(&param, 1);
+
+    st7789_send_cmd(0x36); /* MADCTL */
+    param = 0x00;
+    if (config && config->orientation == DISPLAY_ORIENTATION_LANDSCAPE) {
+        param = 0x60;
+    }
+    st7789_send_data(&param, 1);
+
     ESP_LOGI(TAG, "ST7789 initialized");
 
-    lv_disp_draw_buf_init(&draw_buf, buf, NULL, sizeof(buf) / sizeof(lv_color_t));
+    lv_disp_draw_buf_init(&draw_buf, buf1, buf2, sizeof(buf1) / sizeof(lv_color_t));
     lv_disp_drv_init(&disp_drv);
     disp_drv.flush_cb = disp_flush;
     disp_drv.draw_buf = &draw_buf;
     disp_drv.hor_res = 240;
     disp_drv.ver_res = 320;
+    if (config) {
+        if (config->orientation == DISPLAY_ORIENTATION_LANDSCAPE) {
+            disp_drv.hor_res = 320;
+            disp_drv.ver_res = 240;
+        }
+    }
     lv_disp_drv_register(&disp_drv);
     return ESP_OK;
 }

--- a/components/display/include/display.h
+++ b/components/display/include/display.h
@@ -2,8 +2,23 @@
 
 #include "esp_err.h"
 
+typedef enum {
+    DISPLAY_ORIENTATION_PORTRAIT,
+    DISPLAY_ORIENTATION_LANDSCAPE,
+} display_orientation_t;
+
+typedef enum {
+    DISPLAY_COLOR_FORMAT_RGB565,
+    DISPLAY_COLOR_FORMAT_RGB666,
+} display_color_format_t;
+
+typedef struct {
+    display_orientation_t orientation;
+    display_color_format_t color_format;
+} display_config_t;
+
 /** Initialize ST7789 display and LVGL */
-esp_err_t display_init(void);
+esp_err_t display_init(const display_config_t *config);
 
 /** Periodically call from main loop to update LVGL */
 void display_update(void);

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -33,7 +33,11 @@ void app_main(void)
         ESP_LOGE(TAG, "backlight_init failed: %s", esp_err_to_name(err));
         return;
     }
-    err = display_init();
+    display_config_t disp_cfg = {
+        .orientation = DISPLAY_ORIENTATION_PORTRAIT,
+        .color_format = DISPLAY_COLOR_FORMAT_RGB565,
+    };
+    err = display_init(&disp_cfg);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "display_init failed: %s", esp_err_to_name(err));
         return;


### PR DESCRIPTION
## Summary
- send address window commands during LVGL flush so only changed areas update
- enable LVGL double buffering for smoother DMA transfers
- allow configuring orientation and color format via `display_config_t`
- adjust app main to pass display configuration

## Testing
- `idf.py --version` *(fails: command not found)*
- `idf.py test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874163b916483239b918187eaabcc4b