### PR TITLE
Implement inactivity-triggered light sleep

### DIFF
--- a/components/buttons/buttons.c
+++ b/components/buttons/buttons.c
@@ -1,9 +1,39 @@
 #include "buttons.h"
 #include "esp_log.h"
+#include "driver/gpio.h"
+#include "power.h"
+
+#define BUTTON_PIN 1
+
+static void IRAM_ATTR button_isr(void *arg)
+{
+    power_register_activity();
+}
 
 esp_err_t buttons_init(void)
 {
-    // Placeholder initialization
+    gpio_config_t io_conf = {
+        .pin_bit_mask = 1ULL << BUTTON_PIN,
+        .mode = GPIO_MODE_INPUT,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_NEGEDGE,
+    };
+    esp_err_t err = gpio_config(&io_conf);
+    if (err != ESP_OK) {
+        ESP_LOGE("buttons", "gpio_config failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = gpio_install_isr_service(0);
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE("buttons", "isr service failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = gpio_isr_handler_add(BUTTON_PIN, button_isr, NULL);
+    if (err != ESP_OK) {
+        ESP_LOGE("buttons", "isr add failed: %s", esp_err_to_name(err));
+        return err;
+    }
     ESP_LOGI("buttons", "Initializing buttons");
     return ESP_OK;
 }

--- a/components/keyboard/keyboard.c
+++ b/components/keyboard/keyboard.c
@@ -3,6 +3,7 @@
 #include "driver/gpio.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "power.h"
 
 #define TAG "keyboard"
 
@@ -15,6 +16,7 @@ static const gpio_num_t col_pins[KB_COLS] = {6, 7, 8, 9};
 static uint8_t debounce_cnt[KB_ROWS][KB_COLS];
 static bool key_state[KB_ROWS][KB_COLS];
 static uint16_t key_mask;
+static uint16_t prev_mask;
 
 static void keyboard_task(void *arg)
 {
@@ -55,6 +57,10 @@ static void keyboard_task(void *arg)
             }
         }
 
+        if (mask != prev_mask) {
+            power_register_activity();
+            prev_mask = mask;
+        }
         key_mask = mask;
         vTaskDelay(pdMS_TO_TICKS(10));
     }

--- a/components/power/include/power.h
+++ b/components/power/include/power.h
@@ -11,3 +11,7 @@ void power_high_performance(void);
 /** Switch CPU to low power mode */
 void power_low_power(void);
 
+/** Register a user activity event */
+void power_register_activity(void);
+
+

--- a/components/power/power.c
+++ b/components/power/power.c
@@ -1,10 +1,20 @@
 #include "power.h"
 #include "esp_log.h"
 #include "esp_pm.h"
+#include "esp_sleep.h"
+#include "esp_timer.h"
+#include "driver/gpio.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 #define TAG "power"
 
 static esp_pm_lock_handle_t s_performance_lock;
+static int64_t s_last_activity_us;
+static TaskHandle_t s_monitor_task;
+
+#define WAKEUP_GPIO_MASK ((1ULL<<2) | (1ULL<<3) | (1ULL<<4) | (1ULL<<5) | \
+                          (1ULL<<6) | (1ULL<<7) | (1ULL<<8) | (1ULL<<9))
 
 esp_err_t power_init(void)
 {
@@ -14,6 +24,12 @@ esp_err_t power_init(void)
         return err;
     }
     ESP_LOGI(TAG, "Power management initialized");
+
+    s_last_activity_us = esp_timer_get_time();
+    if (xTaskCreate(inactivity_task, "inactivity_task", 2048, NULL, 5, &s_monitor_task) != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create inactivity task");
+        return ESP_FAIL;
+    }
     return ESP_OK;
 }
 
@@ -28,4 +44,26 @@ void power_low_power(void)
     esp_pm_lock_release(s_performance_lock);
     ESP_LOGI(TAG, "Low power mode");
 }
+
+void power_register_activity(void)
+{
+    s_last_activity_us = esp_timer_get_time();
+}
+
+static void inactivity_task(void *arg)
+{
+    while (1) {
+        int64_t now = esp_timer_get_time();
+        if (now - s_last_activity_us > 30 * 1000000LL) {
+            power_low_power();
+            esp_sleep_enable_ext1_wakeup(WAKEUP_GPIO_MASK, ESP_EXT1_WAKEUP_ANY_HIGH);
+            esp_sleep_enable_touchpad_wakeup();
+            esp_light_sleep_start();
+            power_high_performance();
+            s_last_activity_us = esp_timer_get_time();
+        }
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}
+
 

--- a/components/touch/touch.c
+++ b/components/touch/touch.c
@@ -1,10 +1,18 @@
 #include "touch.h"
 #include "esp_log.h"
 #include "driver/i2c.h"
+#include "driver/gpio.h"
+#include "power.h"
 
 #define TAG "touch"
 
 static bool has_touch = false;
+#define TOUCH_INT_PIN 4
+
+static void IRAM_ATTR touch_isr(void *arg)
+{
+    power_register_activity();
+}
 
 esp_err_t touch_init(void)
 {
@@ -24,6 +32,29 @@ esp_err_t touch_init(void)
     err = i2c_driver_install(I2C_NUM_0, conf.mode, 0, 0, 0);
     if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
         ESP_LOGE(TAG, "i2c_driver_install failed: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    gpio_config_t io_conf = {
+        .pin_bit_mask = 1ULL << TOUCH_INT_PIN,
+        .mode = GPIO_MODE_INPUT,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_NEGEDGE,
+    };
+    err = gpio_config(&io_conf);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "gpio_config failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = gpio_install_isr_service(0);
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "isr service failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = gpio_isr_handler_add(TOUCH_INT_PIN, touch_isr, NULL);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "isr add failed: %s", esp_err_to_name(err));
         return err;
     }
 

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -5,6 +5,7 @@
 #include "backlight.h"
 #include "keyboard.h"
 #include "touch.h"
+#include "buttons.h"
 #include "network.h"
 #include "storage_sd.h"
 #include "power.h"
@@ -28,6 +29,7 @@ void app_main(void)
         ESP_LOGE(TAG, "power_init failed: %s", esp_err_to_name(err));
         return;
     }
+    power_high_performance();
     err = backlight_init();
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "backlight_init failed: %s", esp_err_to_name(err));
@@ -45,6 +47,11 @@ void app_main(void)
     err = keyboard_init();
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "keyboard_init failed: %s", esp_err_to_name(err));
+        return;
+    }
+    err = buttons_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "buttons_init failed: %s", esp_err_to_name(err));
         return;
     }
     err = touch_init();


### PR DESCRIPTION
## Summary
- monitor keyboard, touch and button activity
- enter light sleep after 30s of inactivity
- wake on GPIO or touch interrupt and switch back to performance mode
- initialize buttons and enable high performance at startup

## Testing
- `idf.py test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68741de08f088323aa8806c36a64afc9