### PR TITLE
Add LVGL touch driver and calibration storage

### DIFF
--- a/components/touch/include/touch.h
+++ b/components/touch/include/touch.h
@@ -8,3 +8,14 @@ esp_err_t touch_init(void);
 /** Read touch coordinates, returns true if touched */
 bool touch_read(uint16_t *x, uint16_t *y);
 
+typedef struct {
+    uint16_t x0;
+    uint16_t y0;
+    uint16_t x1;
+    uint16_t y1;
+} touch_calibration_t;
+
+esp_err_t touch_calibration_load(touch_calibration_t *cal);
+esp_err_t touch_calibration_save(const touch_calibration_t *cal);
+
+

--- a/components/touch/touch.c
+++ b/components/touch/touch.c
@@ -2,20 +2,42 @@
 #include "esp_log.h"
 #include "driver/i2c.h"
 #include "driver/gpio.h"
+#include "nvs_flash.h"
+#include "nvs.h"
+#include "lvgl.h"
 #include "power.h"
 
 #define TAG "touch"
 
 static bool has_touch = false;
 #define TOUCH_INT_PIN 4
+#define TOUCH_ADDR 0x38
+
+static touch_calibration_t s_cal = {0, 0, 320, 240};
+
+static lv_indev_t *s_indev;
 
 static void IRAM_ATTR touch_isr(void *arg)
 {
     power_register_activity();
 }
 
+static void lv_touch_read(lv_indev_drv_t *drv, lv_indev_data_t *data)
+{
+    uint16_t x, y;
+    if (touch_read(&x, &y)) {
+        data->state = LV_INDEV_STATE_PR;
+        data->point.x = x;
+        data->point.y = y;
+    } else {
+        data->state = LV_INDEV_STATE_REL;
+    }
+}
+
 esp_err_t touch_init(void)
 {
+    nvs_flash_init();
+
     i2c_config_t conf = {
         .mode = I2C_MODE_MASTER,
         .sda_io_num = 3,
@@ -58,6 +80,17 @@ esp_err_t touch_init(void)
         return err;
     }
 
+    touch_calibration_t cal;
+    if (touch_calibration_load(&cal) == ESP_OK) {
+        s_cal = cal;
+    }
+
+    lv_indev_drv_t drv;
+    lv_indev_drv_init(&drv);
+    drv.type = LV_INDEV_TYPE_POINTER;
+    drv.read_cb = lv_touch_read;
+    s_indev = lv_indev_drv_register(&drv);
+
     has_touch = true;
     ESP_LOGI(TAG, "Touch controller initialized");
     return ESP_OK;
@@ -66,9 +99,61 @@ esp_err_t touch_init(void)
 bool touch_read(uint16_t *x, uint16_t *y)
 {
     if (!has_touch) return false;
-    /* In real implementation read I2C registers */
-    *x = 0;
-    *y = 0;
-    return false;
+    uint8_t reg = 0x02;
+    uint8_t data[5];
+    esp_err_t err = i2c_master_write_read_device(I2C_NUM_0, TOUCH_ADDR,
+                                                 &reg, 1, data, sizeof(data),
+                                                 pdMS_TO_TICKS(50));
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "i2c read failed: %s", esp_err_to_name(err));
+        return false;
+    }
+    if ((data[0] & 0x0F) == 0) {
+        return false;
+    }
+    uint16_t raw_x = ((data[1] & 0x0F) << 8) | data[2];
+    uint16_t raw_y = ((data[3] & 0x0F) << 8) | data[4];
+
+    int32_t cal_x = (int32_t)(raw_x - s_cal.x0) * 320 / (s_cal.x1 - s_cal.x0);
+    int32_t cal_y = (int32_t)(raw_y - s_cal.y0) * 240 / (s_cal.y1 - s_cal.y0);
+
+    if (cal_x < 0) cal_x = 0;
+    if (cal_x > 319) cal_x = 319;
+    if (cal_y < 0) cal_y = 0;
+    if (cal_y > 239) cal_y = 239;
+
+    *x = cal_x;
+    *y = cal_y;
+    return true;
+}
+
+esp_err_t touch_calibration_load(touch_calibration_t *cal)
+{
+    if (!cal) return ESP_ERR_INVALID_ARG;
+    nvs_handle_t nvs;
+    esp_err_t err = nvs_open("touch", NVS_READONLY, &nvs);
+    if (err != ESP_OK) {
+        return err;
+    }
+    size_t len = sizeof(touch_calibration_t);
+    err = nvs_get_blob(nvs, "cal", cal, &len);
+    nvs_close(nvs);
+    return err;
+}
+
+esp_err_t touch_calibration_save(const touch_calibration_t *cal)
+{
+    if (!cal) return ESP_ERR_INVALID_ARG;
+    nvs_handle_t nvs;
+    esp_err_t err = nvs_open("touch", NVS_READWRITE, &nvs);
+    if (err != ESP_OK) {
+        return err;
+    }
+    err = nvs_set_blob(nvs, "cal", cal, sizeof(touch_calibration_t));
+    if (err == ESP_OK) {
+        err = nvs_commit(nvs);
+    }
+    nvs_close(nvs);
+    return err;
 }
 


### PR DESCRIPTION
## Summary
- implement I²C transactions for the touch controller
- provide LVGL input driver that reports touch events
- add simple NVS-based calibration storage

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68741f8d07d88323808f070f7b2ad737