### PR TITLE
Add power inactivity and network error handling tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 idf_component_register(
-    SRCS "test_main.c" "test_display.c" "test_keyboard.c" "test_power.c" "Unity/src/unity.c"
-         "mocks/mock_spi.c" "mocks/mock_i2c.c" "mocks/mock_gpio.c" "mocks/mock_freertos.c" "mocks/mock_adc.c"
+    SRCS "test_main.c" "test_display.c" "test_keyboard.c" "test_power.c" "test_network.c" "Unity/src/unity.c" 
+         "mocks/mock_spi.c" "mocks/mock_i2c.c" "mocks/mock_gpio.c" "mocks/mock_freertos.c" "mocks/mock_adc.c" "mocks/mock_esp.c" "mocks/mock_wifi.c"
     INCLUDE_DIRS "." "Unity/src" "mocks"
-                 "../components/display/include" "../components/keyboard/include" "../components/touch/include" "../components/power/include"
+                 "../components/display/include" "../components/keyboard/include" "../components/touch/include" "../components/power/include" "../components/network/include"
     PRIV_REQUIRES)
+

--- a/tests/mocks/mock_esp.c
+++ b/tests/mocks/mock_esp.c
@@ -1,0 +1,50 @@
+#include "mock_esp.h"
+
+int64_t mock_esp_timer_us = 0;
+int mock_light_sleep_count = 0;
+int mock_pm_acquire_count = 0;
+int mock_pm_release_count = 0;
+
+esp_err_t esp_pm_lock_create(esp_pm_lock_type_t lock_type, int arg1, const char *name, esp_pm_lock_handle_t *out_handle)
+{
+    (void)lock_type; (void)arg1; (void)name;
+    if (out_handle) *out_handle = (esp_pm_lock_handle_t)0x1;
+    return ESP_OK;
+}
+
+esp_err_t esp_pm_lock_acquire(esp_pm_lock_handle_t handle)
+{
+    (void)handle;
+    mock_pm_acquire_count++;
+    return ESP_OK;
+}
+
+esp_err_t esp_pm_lock_release(esp_pm_lock_handle_t handle)
+{
+    (void)handle;
+    mock_pm_release_count++;
+    return ESP_OK;
+}
+
+esp_err_t esp_sleep_enable_ext1_wakeup(uint64_t mask, esp_ext1_wakeup_mode_t mode)
+{
+    (void)mask; (void)mode;
+    return ESP_OK;
+}
+
+esp_err_t esp_sleep_enable_touchpad_wakeup(void)
+{
+    return ESP_OK;
+}
+
+esp_err_t esp_light_sleep_start(void)
+{
+    mock_light_sleep_count++;
+    return ESP_OK;
+}
+
+int64_t esp_timer_get_time(void)
+{
+    return mock_esp_timer_us;
+}
+

--- a/tests/mocks/mock_esp.h
+++ b/tests/mocks/mock_esp.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "esp_err.h"
+#include "esp_pm.h"
+#include "esp_sleep.h"
+#include "esp_timer.h"
+
+extern int64_t mock_esp_timer_us;
+extern int mock_light_sleep_count;
+extern int mock_pm_acquire_count;
+extern int mock_pm_release_count;
+
+esp_err_t esp_pm_lock_create(esp_pm_lock_type_t lock_type, int arg1, const char *name, esp_pm_lock_handle_t *out_handle);
+esp_err_t esp_pm_lock_acquire(esp_pm_lock_handle_t handle);
+esp_err_t esp_pm_lock_release(esp_pm_lock_handle_t handle);
+
+esp_err_t esp_sleep_enable_ext1_wakeup(uint64_t mask, esp_ext1_wakeup_mode_t mode);
+esp_err_t esp_sleep_enable_touchpad_wakeup(void);
+esp_err_t esp_light_sleep_start(void);
+
+int64_t esp_timer_get_time(void);
+

--- a/tests/mocks/mock_wifi.c
+++ b/tests/mocks/mock_wifi.c
@@ -1,0 +1,56 @@
+#include "mock_wifi.h"
+
+esp_err_t mock_nvs_flash_init_ret = ESP_OK;
+esp_err_t mock_esp_netif_init_ret = ESP_OK;
+esp_err_t mock_esp_event_loop_create_default_ret = ESP_OK;
+esp_err_t mock_esp_wifi_init_ret = ESP_OK;
+esp_err_t mock_esp_wifi_set_mode_ret = ESP_OK;
+esp_err_t mock_esp_wifi_set_config_ret = ESP_OK;
+esp_err_t mock_esp_event_handler_instance_register_ret = ESP_OK;
+esp_err_t mock_esp_wifi_start_ret = ESP_OK;
+esp_err_t mock_esp_bt_controller_mem_release_ret = ESP_OK;
+esp_err_t mock_esp_bt_controller_init_ret = ESP_OK;
+esp_err_t mock_esp_bt_controller_enable_ret = ESP_OK;
+esp_err_t mock_esp_bluedroid_init_ret = ESP_OK;
+esp_err_t mock_esp_bluedroid_enable_ret = ESP_OK;
+
+static lv_obj_t dummy;
+
+void * lv_scr_act(void)
+{
+    return NULL;
+}
+
+lv_obj_t * lv_label_create(const void *parent)
+{
+    (void)parent;
+    return &dummy;
+}
+
+void lv_label_set_text(lv_obj_t *obj, const char *text)
+{
+    (void)obj; (void)text;
+}
+
+esp_err_t nvs_flash_init(void) { return mock_nvs_flash_init_ret; }
+esp_err_t esp_netif_init(void) { return mock_esp_netif_init_ret; }
+esp_err_t esp_event_loop_create_default(void) { return mock_esp_event_loop_create_default_ret; }
+esp_err_t esp_wifi_init(const wifi_init_config_t *cfg) { (void)cfg; return mock_esp_wifi_init_ret; }
+esp_netif_t * esp_netif_create_default_wifi_sta(void) { return (esp_netif_t*)0x1; }
+esp_err_t esp_wifi_set_mode(wifi_mode_t mode) { (void)mode; return mock_esp_wifi_set_mode_ret; }
+esp_err_t esp_wifi_set_config(wifi_interface_t iface, const wifi_config_t *cfg) { (void)iface; (void)cfg; return mock_esp_wifi_set_config_ret; }
+esp_err_t esp_event_handler_instance_register(esp_event_base_t event_base, int32_t event_id, esp_event_handler_t event_handler, void *event_handler_arg, esp_event_handler_instance_t *instance_out)
+{
+    (void)event_base; (void)event_id; (void)event_handler; (void)event_handler_arg; (void)instance_out;
+    return mock_esp_event_handler_instance_register_ret;
+}
+esp_err_t esp_wifi_start(void) { return mock_esp_wifi_start_ret; }
+esp_err_t esp_bt_controller_mem_release(esp_bt_mode_t mode) { (void)mode; return mock_esp_bt_controller_mem_release_ret; }
+esp_err_t esp_bt_controller_init(const esp_bt_controller_config_t *cfg) { (void)cfg; return mock_esp_bt_controller_init_ret; }
+esp_err_t esp_bt_controller_enable(esp_bt_mode_t mode) { (void)mode; return mock_esp_bt_controller_enable_ret; }
+esp_err_t esp_bluedroid_init(void) { return mock_esp_bluedroid_init_ret; }
+esp_err_t esp_bluedroid_enable(void) { return mock_esp_bluedroid_enable_ret; }
+esp_err_t esp_ble_gatts_register_callback(esp_gatts_cb_t callback) { (void)callback; return ESP_OK; }
+esp_err_t esp_ble_gatts_app_register(uint16_t app_id) { (void)app_id; return ESP_OK; }
+esp_err_t esp_ble_gap_start_advertising(const esp_ble_adv_params_t *params) { (void)params; return ESP_OK; }
+

--- a/tests/mocks/mock_wifi.h
+++ b/tests/mocks/mock_wifi.h
@@ -1,0 +1,51 @@
+#pragma once
+#include "esp_err.h"
+#include "esp_wifi.h"
+#include "esp_event.h"
+#include "nvs_flash.h"
+#include "esp_bt.h"
+#include "esp_bt_main.h"
+#include "esp_gap_ble_api.h"
+#include "esp_gatts_api.h"
+#include "lvgl.h"
+
+typedef struct lv_obj_t {
+    int dummy;
+} lv_obj_t;
+
+extern esp_err_t mock_nvs_flash_init_ret;
+extern esp_err_t mock_esp_netif_init_ret;
+extern esp_err_t mock_esp_event_loop_create_default_ret;
+extern esp_err_t mock_esp_wifi_init_ret;
+extern esp_err_t mock_esp_wifi_set_mode_ret;
+extern esp_err_t mock_esp_wifi_set_config_ret;
+extern esp_err_t mock_esp_event_handler_instance_register_ret;
+extern esp_err_t mock_esp_wifi_start_ret;
+extern esp_err_t mock_esp_bt_controller_mem_release_ret;
+extern esp_err_t mock_esp_bt_controller_init_ret;
+extern esp_err_t mock_esp_bt_controller_enable_ret;
+extern esp_err_t mock_esp_bluedroid_init_ret;
+extern esp_err_t mock_esp_bluedroid_enable_ret;
+
+void * lv_scr_act(void);
+lv_obj_t * lv_label_create(const void *parent);
+void lv_label_set_text(lv_obj_t *obj, const char *text);
+
+esp_err_t nvs_flash_init(void);
+esp_err_t esp_netif_init(void);
+esp_err_t esp_event_loop_create_default(void);
+esp_err_t esp_wifi_init(const wifi_init_config_t *cfg);
+esp_netif_t * esp_netif_create_default_wifi_sta(void);
+esp_err_t esp_wifi_set_mode(wifi_mode_t mode);
+esp_err_t esp_wifi_set_config(wifi_interface_t iface, const wifi_config_t *cfg);
+esp_err_t esp_event_handler_instance_register(esp_event_base_t event_base, int32_t event_id, esp_event_handler_t event_handler, void *event_handler_arg, esp_event_handler_instance_t *instance_out);
+esp_err_t esp_wifi_start(void);
+esp_err_t esp_bt_controller_mem_release(esp_bt_mode_t mode);
+esp_err_t esp_bt_controller_init(const esp_bt_controller_config_t *cfg);
+esp_err_t esp_bt_controller_enable(esp_bt_mode_t mode);
+esp_err_t esp_bluedroid_init(void);
+esp_err_t esp_bluedroid_enable(void);
+esp_err_t esp_ble_gatts_register_callback(esp_gatts_cb_t callback);
+esp_err_t esp_ble_gatts_app_register(uint16_t app_id);
+esp_err_t esp_ble_gap_start_advertising(const esp_ble_adv_params_t *params);
+

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -7,6 +7,9 @@ extern void test_keyboard_initial_state(void);
 extern void test_keyboard_init_gpio_fail(void);
 extern void test_keyboard_init_task_fail(void);
 extern void test_power_usage_percent(void);
+extern void test_power_inactivity_timeout(void);
+extern void test_network_init_wifi_init_fail(void);
+extern void test_network_init_wifi_start_fail(void);
 
 void app_main(void)
 {
@@ -18,5 +21,9 @@ void app_main(void)
     RUN_TEST(test_keyboard_init_gpio_fail);
     RUN_TEST(test_keyboard_init_task_fail);
     RUN_TEST(test_power_usage_percent);
+    RUN_TEST(test_power_inactivity_timeout);
+    RUN_TEST(test_network_init_wifi_init_fail);
+    RUN_TEST(test_network_init_wifi_start_fail);
     UNITY_END();
 }
+

--- a/tests/test_network.c
+++ b/tests/test_network.c
@@ -1,0 +1,18 @@
+#include "unity.h"
+#include "network.h"
+#include "mock_wifi.h"
+
+void test_network_init_wifi_init_fail(void)
+{
+    mock_esp_wifi_init_ret = ESP_FAIL;
+    TEST_ASSERT_EQUAL(ESP_FAIL, network_init());
+    mock_esp_wifi_init_ret = ESP_OK;
+}
+
+void test_network_init_wifi_start_fail(void)
+{
+    mock_esp_wifi_start_ret = ESP_FAIL;
+    TEST_ASSERT_EQUAL(ESP_FAIL, network_init());
+    mock_esp_wifi_start_ret = ESP_OK;
+}
+

--- a/tests/test_power.c
+++ b/tests/test_power.c
@@ -13,3 +13,23 @@ void test_power_usage_percent(void)
     mock_adc1_raw_value = 4095;
     TEST_ASSERT_EQUAL_UINT8(100, power_get_usage_percent());
 }
+#include "mock_freertos.h"
+#include "mock_esp.h"
+
+void test_power_inactivity_timeout(void)
+{
+    mock_esp_timer_us = 0;
+    mock_light_sleep_count = 0;
+    mock_pm_acquire_count = 0;
+    mock_pm_release_count = 0;
+    TEST_ASSERT_EQUAL(ESP_OK, power_init());
+    TEST_ASSERT_NOT_NULL(mock_last_task_func);
+
+    mock_esp_timer_us = 31LL * 1000000LL;
+    mock_last_task_func(NULL);
+
+    TEST_ASSERT_EQUAL(1, mock_light_sleep_count);
+    TEST_ASSERT_EQUAL(1, mock_pm_release_count);
+    TEST_ASSERT_EQUAL(1, mock_pm_acquire_count);
+}
+


### PR DESCRIPTION
## Summary
- add mock implementations for esp power control and wifi
- test power inactivity timeout with mocked timers
- test network_init error cases for Wi-Fi init and start
- build new tests in `tests/CMakeLists.txt`

## Testing
- `idf.py test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874cad2680c8323b0e192fe69014454