### PR TITLE
Add SD card unmount and removal handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Run the command from the project root to execute all unit tests using the provid
 
 After flashing, the application brings up the ST7789 LCD with LVGL and starts scanning the keyboard matrix. Wi-Fi 6 and BLE are initialized and their connection state is shown on the status label. The label now updates when a BLE device connects or disconnects. LVGL assets can be loaded from a microSD card and the backlight brightness is controlled by PWM. Touch input is optional and power modes can be switched between high-performance and low-power cores.
 
+### SD Card Usage
+
+Use `storage_sd_init()` to mount the card before loading assets. Call
+`storage_sd_unmount()` prior to removal and invoke `storage_sd_update()` in the
+main loop to detect if the card is unexpectedly removed. When removal is
+detected, an error is logged and displayed on the LVGL interface.
+
 ## GPIO Assignments
 
 | Signal | ESP32-C6-LCD-1.47-M | ESP32-C6-Touch-LCD-1.47-M |

--- a/components/storage_sd/include/storage_sd.h
+++ b/components/storage_sd/include/storage_sd.h
@@ -8,3 +8,9 @@ esp_err_t storage_sd_init(void);
 /** Load a file into memory from the SD card */
 void *storage_sd_load(const char *path, size_t *size);
 
+/** Unmount the microSD card */
+esp_err_t storage_sd_unmount(void);
+
+/** Poll card presence and log LVGL error if removed */
+void storage_sd_update(void);
+

--- a/components/ui/include/ui.h
+++ b/components/ui/include/ui.h
@@ -22,3 +22,6 @@ void ui_show_settings(void);
 /** Update widgets like energy usage */
 void ui_update(void);
 
+/** Display an error message */
+void ui_show_error(const char *msg);
+

--- a/components/ui/ui.c
+++ b/components/ui/ui.c
@@ -25,6 +25,7 @@ static lv_obj_t *home_title;
 static lv_obj_t *settings_title;
 static lv_obj_t *btn_en;
 static lv_obj_t *btn_fr;
+static lv_obj_t *error_label;
 
 static const char *get_str(ui_str_id_t id)
 {
@@ -52,6 +53,11 @@ esp_err_t ui_init(void)
     lv_obj_set_size(energy_bar, 200, 20);
     lv_obj_align(energy_bar, LV_ALIGN_CENTER, 0, 0);
     lv_bar_set_range(energy_bar, 0, 100);
+
+    error_label = lv_label_create(home_screen);
+    lv_obj_align(error_label, LV_ALIGN_BOTTOM_MID, 0, -10);
+    lv_obj_set_style_text_color(error_label, lv_palette_main(LV_PALETTE_RED), 0);
+    lv_label_set_text(error_label, "");
 
     settings_screen = lv_obj_create(NULL);
     settings_title = lv_label_create(settings_screen);
@@ -96,5 +102,10 @@ void ui_show_settings(void)
 void ui_update(void)
 {
     lv_bar_set_value(energy_bar, power_get_usage_percent(), LV_ANIM_OFF);
+}
+
+void ui_show_error(const char *msg)
+{
+    lv_label_set_text(error_label, msg);
 }
 

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -83,6 +83,7 @@ void app_main(void)
     while (1) {
         ui_update();
         display_update();
+        storage_sd_update();
         network_update();
         vTaskDelay(pdMS_TO_TICKS(5));
     }


### PR DESCRIPTION
## Summary
- add `storage_sd_unmount()` and `storage_sd_update()`
- show SD card errors on the LVGL interface
- call update loop from `app_main`
- document SD card API usage in README

## Testing
- `pip install idf-component-manager`
- `idf.py test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874ced460fc832389abded4c4b0a709