### PR TITLE
Add network status screen

### DIFF
--- a/components/ui/include/ui.h
+++ b/components/ui/include/ui.h
@@ -19,6 +19,12 @@ void ui_show_home(void);
 /** Show settings screen */
 void ui_show_settings(void);
 
+/** Show network status screen */
+void ui_show_network(void);
+
+/** Update the network status information */
+void ui_update_network(const char *ssid, const char *ip, bool ble_connected);
+
 /** Update widgets like energy usage */
 void ui_update(void);
 

--- a/components/ui/ui.c
+++ b/components/ui/ui.c
@@ -20,12 +20,15 @@ static ui_lang_t s_lang = UI_LANG_EN;
 
 static lv_obj_t *home_screen;
 static lv_obj_t *settings_screen;
+static lv_obj_t *network_screen;
 static lv_obj_t *energy_bar;
 static lv_obj_t *home_title;
 static lv_obj_t *settings_title;
+static lv_obj_t *network_title;
 static lv_obj_t *btn_en;
 static lv_obj_t *btn_fr;
 static lv_obj_t *error_label;
+static lv_obj_t *network_label;
 
 static const char *get_str(ui_str_id_t id)
 {
@@ -63,6 +66,13 @@ esp_err_t ui_init(void)
     settings_title = lv_label_create(settings_screen);
     lv_obj_align(settings_title, LV_ALIGN_TOP_MID, 0, 10);
 
+    network_screen = lv_obj_create(NULL);
+    network_title = lv_label_create(network_screen);
+    lv_obj_align(network_title, LV_ALIGN_TOP_MID, 0, 10);
+    lv_label_set_text(network_title, "Network");
+    network_label = lv_label_create(network_screen);
+    lv_obj_align(network_label, LV_ALIGN_CENTER, 0, 0);
+
     btn_en = lv_btn_create(settings_screen);
     lv_obj_align(btn_en, LV_ALIGN_LEFT_MID, 10, 0);
     lv_obj_t *lbl_en = lv_label_create(btn_en);
@@ -99,9 +109,24 @@ void ui_show_settings(void)
     lv_scr_load(settings_screen);
 }
 
+void ui_show_network(void)
+{
+    lv_scr_load(network_screen);
+}
+
 void ui_update(void)
 {
     lv_bar_set_value(energy_bar, power_get_usage_percent(), LV_ANIM_OFF);
+}
+
+void ui_update_network(const char *ssid, const char *ip, bool ble_connected)
+{
+    char buf[96];
+    snprintf(buf, sizeof(buf), "SSID: %s\nIP: %s\nBLE: %s",
+             ssid,
+             ip,
+             ble_connected ? "Connected" : "Advertising");
+    lv_label_set_text(network_label, buf);
 }
 
 void ui_show_error(const char *msg)

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -80,7 +80,21 @@ void app_main(void)
     ui_show_home();
     xTaskCreate(hello_task, "hello_task", 2048, NULL, 5, NULL);
 
+    uint16_t prev_keys = 0;
+
     while (1) {
+        uint16_t keys = keyboard_get_state();
+        if (keys != prev_keys) {
+            if (keys & 1) {
+                ui_show_home();
+            } else if (keys & 2) {
+                ui_show_settings();
+            } else if (keys & 4) {
+                ui_show_network();
+            }
+            prev_keys = keys;
+        }
+
         ui_update();
         display_update();
         storage_sd_update();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(
-    SRCS "test_main.c" "test_display.c" "test_keyboard.c" "test_power.c" "test_network.c" "Unity/src/unity.c" 
-         "mocks/mock_spi.c" "mocks/mock_i2c.c" "mocks/mock_gpio.c" "mocks/mock_freertos.c" "mocks/mock_adc.c" "mocks/mock_esp.c" "mocks/mock_wifi.c"
+    SRCS "test_main.c" "test_display.c" "test_keyboard.c" "test_power.c" "test_network.c" "Unity/src/unity.c"
+         "mocks/mock_spi.c" "mocks/mock_i2c.c" "mocks/mock_gpio.c" "mocks/mock_freertos.c" "mocks/mock_adc.c" "mocks/mock_esp.c" "mocks/mock_wifi.c" "mocks/mock_ui.c"
     INCLUDE_DIRS "." "Unity/src" "mocks"
-                 "../components/display/include" "../components/keyboard/include" "../components/touch/include" "../components/power/include" "../components/network/include"
+                 "../components/display/include" "../components/keyboard/include" "../components/touch/include" "../components/power/include" "../components/network/include" "../components/ui/include"
     PRIV_REQUIRES)
 

--- a/tests/mocks/mock_ui.c
+++ b/tests/mocks/mock_ui.c
@@ -1,0 +1,5 @@
+#include "mock_ui.h"
+void ui_show_error(const char *msg) { (void)msg; }
+void ui_update_network(const char *ssid, const char *ip, bool ble_connected) {
+    (void)ssid; (void)ip; (void)ble_connected;
+}

--- a/tests/mocks/mock_ui.h
+++ b/tests/mocks/mock_ui.h
@@ -1,0 +1,3 @@
+#pragma once
+void ui_show_error(const char *msg);
+void ui_update_network(const char *ssid, const char *ip, bool ble_connected);


### PR DESCRIPTION
## Summary
- extend UI with network screen for Wi-Fi and BLE
- surface network errors with `ui_show_error`
- let keyboard cycle through screens
- adapt network module for new UI
- add test stubs for UI functions

## Testing
- `idf.py test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874d70e7aa48323983d530fb4263319