### PR TITLE
Add keyboard menu navigation

### DIFF
--- a/components/menu/CMakeLists.txt
+++ b/components/menu/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "menu.c" INCLUDE_DIRS "include" REQUIRES keyboard ui)

--- a/components/menu/include/menu.h
+++ b/components/menu/include/menu.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <stdint.h>
+void menu_update(void);
+void menu_process_keys(uint16_t keys);

--- a/components/menu/menu.c
+++ b/components/menu/menu.c
@@ -1,0 +1,27 @@
+#include "menu.h"
+#include "keyboard.h"
+#include "ui.h"
+
+static uint16_t s_prev_keys;
+
+void menu_process_keys(uint16_t keys)
+{
+    if (keys & 1) {
+        ui_show_home();
+    } else if (keys & 2) {
+        ui_show_settings();
+    } else if (keys & 4) {
+        ui_show_network();
+    } else if (keys & 8) {
+        ui_show_images();
+    }
+}
+
+void menu_update(void)
+{
+    uint16_t keys = keyboard_get_state();
+    if (keys != s_prev_keys) {
+        s_prev_keys = keys;
+        menu_process_keys(keys);
+    }
+}

--- a/components/ui/include/ui.h
+++ b/components/ui/include/ui.h
@@ -8,6 +8,14 @@ typedef enum {
     UI_LANG_COUNT,
 } ui_lang_t;
 
+typedef enum {
+    UI_PAGE_HOME,
+    UI_PAGE_SETTINGS,
+    UI_PAGE_NETWORK,
+    UI_PAGE_IMAGES,
+    UI_PAGE_COUNT
+} ui_page_t;
+
 /** Load or replace a language table */
 void ui_load_language(ui_lang_t lang, const char *const table[]);
 
@@ -37,4 +45,7 @@ void ui_show_error(const char *msg);
 
 /** Show SD card image browser */
 void ui_show_images(void);
+
+/** Highlight the active navigation item */
+void ui_set_active_page(ui_page_t page);
 

--- a/components/ui/ui.c
+++ b/components/ui/ui.c
@@ -10,6 +10,7 @@ typedef enum {
     UI_STR_HOME_TITLE,
     UI_STR_SETTINGS_TITLE,
     UI_STR_NETWORK_TITLE,
+    UI_STR_IMAGES_TITLE,
     UI_STR_ENERGY_USAGE,
     UI_STR_LANGUAGE_EN,
     UI_STR_LANGUAGE_FR,
@@ -25,6 +26,7 @@ static const char *s_lang_table[UI_LANG_COUNT][UI_STR_COUNT] = {
         "Home",
         "Settings",
         "Network",
+        "Images",
         "Energy",
         "English",
         "French",
@@ -37,6 +39,7 @@ static const char *s_lang_table[UI_LANG_COUNT][UI_STR_COUNT] = {
         "Accueil",
         "Param\xC3\xA8tres",
         "R\xC3\xA9seau",
+        "Images",
         "Energie",
         "Anglais",
         "Fran\xC3\xA7ais",
@@ -65,6 +68,8 @@ static lv_obj_t *brightness_slider;
 static lv_obj_t *images_screen;
 static lv_obj_t *images_list;
 static lv_obj_t *images_img;
+static lv_obj_t *images_title;
+static ui_page_t s_active_page = UI_PAGE_HOME;
 
 void ui_load_language(ui_lang_t lang, const char *const table[])
 {
@@ -155,6 +160,8 @@ esp_err_t ui_init(void)
     lv_obj_align(network_label, LV_ALIGN_CENTER, 0, 0);
 
     images_screen = lv_obj_create(NULL);
+    images_title = lv_label_create(images_screen);
+    lv_obj_align(images_title, LV_ALIGN_TOP_MID, 0, 10);
     images_list = lv_list_create(images_screen);
     lv_obj_set_size(images_list, 100, 200);
     lv_obj_align(images_list, LV_ALIGN_LEFT_MID, 0, 0);
@@ -183,6 +190,7 @@ esp_err_t ui_init(void)
     lv_obj_add_event_cb(brightness_slider, brightness_event_cb, LV_EVENT_VALUE_CHANGED, NULL);
 
     ui_set_language(s_lang);
+    ui_set_active_page(UI_PAGE_HOME);
     lv_scr_load(home_screen);
     return ESP_OK;
 }
@@ -193,6 +201,7 @@ void ui_set_language(ui_lang_t lang)
     lv_label_set_text(home_title, get_str(UI_STR_HOME_TITLE));
     lv_label_set_text(settings_title, get_str(UI_STR_SETTINGS_TITLE));
     lv_label_set_text(network_title, get_str(UI_STR_NETWORK_TITLE));
+    lv_label_set_text(images_title, get_str(UI_STR_IMAGES_TITLE));
     lv_label_set_text(lv_obj_get_child(btn_en, 0), get_str(UI_STR_LANGUAGE_EN));
     lv_label_set_text(lv_obj_get_child(btn_fr, 0), get_str(UI_STR_LANGUAGE_FR));
     lv_label_set_text(brightness_label, get_str(UI_STR_BRIGHTNESS));
@@ -201,22 +210,26 @@ void ui_set_language(ui_lang_t lang)
 void ui_show_home(void)
 {
     lv_scr_load(home_screen);
+    ui_set_active_page(UI_PAGE_HOME);
 }
 
 void ui_show_settings(void)
 {
     lv_scr_load(settings_screen);
+    ui_set_active_page(UI_PAGE_SETTINGS);
 }
 
 void ui_show_network(void)
 {
     lv_scr_load(network_screen);
+    ui_set_active_page(UI_PAGE_NETWORK);
 }
 
 void ui_show_images(void)
 {
     populate_images();
     lv_scr_load(images_screen);
+    ui_set_active_page(UI_PAGE_IMAGES);
 }
 
 void ui_update(void)
@@ -238,5 +251,16 @@ void ui_update_network(const char *ssid, const char *ip, bool ble_connected)
 void ui_show_error(const char *msg)
 {
     lv_label_set_text(error_label, msg);
+}
+
+void ui_set_active_page(ui_page_t page)
+{
+    s_active_page = page;
+    lv_color_t active = lv_palette_main(LV_PALETTE_BLUE);
+    lv_color_t inactive = lv_palette_main(LV_PALETTE_GREY);
+    lv_obj_set_style_text_color(home_title, page == UI_PAGE_HOME ? active : inactive, 0);
+    lv_obj_set_style_text_color(settings_title, page == UI_PAGE_SETTINGS ? active : inactive, 0);
+    lv_obj_set_style_text_color(network_title, page == UI_PAGE_NETWORK ? active : inactive, 0);
+    lv_obj_set_style_text_color(images_title, page == UI_PAGE_IMAGES ? active : inactive, 0);
 }
 

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -80,22 +80,8 @@ void app_main(void)
     ui_show_home();
     xTaskCreate(hello_task, "hello_task", 2048, NULL, 5, NULL);
 
-    uint16_t prev_keys = 0;
-
     while (1) {
-        uint16_t keys = keyboard_get_state();
-        if (keys != prev_keys) {
-            if (keys & 1) {
-                ui_show_home();
-            } else if (keys & 2) {
-                ui_show_settings();
-            } else if (keys & 4) {
-                ui_show_network();
-            } else if (keys & 8) {
-                ui_show_images();
-            }
-            prev_keys = keys;
-        }
+        menu_update();
 
         ui_update();
         display_update();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(
-    SRCS "test_main.c" "test_display.c" "test_keyboard.c" "test_power.c" "test_network.c" "Unity/src/unity.c"
-         "mocks/mock_spi.c" "mocks/mock_i2c.c" "mocks/mock_gpio.c" "mocks/mock_freertos.c" "mocks/mock_adc.c" "mocks/mock_esp.c" "mocks/mock_wifi.c" "mocks/mock_ui.c"
+    SRCS "test_main.c" "test_display.c" "test_keyboard.c" "test_power.c" "test_network.c" "test_menu.c" "Unity/src/unity.c"
+         "mocks/mock_spi.c" "mocks/mock_i2c.c" "mocks/mock_gpio.c" "mocks/mock_freertos.c" "mocks/mock_adc.c" "mocks/mock_esp.c" "mocks/mock_wifi.c" "mocks/mock_ui.c" "mocks/mock_keyboard.c"
     INCLUDE_DIRS "." "Unity/src" "mocks"
-                 "../components/display/include" "../components/keyboard/include" "../components/touch/include" "../components/power/include" "../components/network/include" "../components/ui/include"
+                 "../components/display/include" "../components/keyboard/include" "../components/touch/include" "../components/power/include" "../components/network/include" "../components/ui/include" "../components/menu/include"
     PRIV_REQUIRES)
 

--- a/tests/mocks/mock_keyboard.c
+++ b/tests/mocks/mock_keyboard.c
@@ -1,0 +1,3 @@
+#include "mock_keyboard.h"
+uint16_t mock_keyboard_state = 0;
+uint16_t keyboard_get_state(void) { return mock_keyboard_state; }

--- a/tests/mocks/mock_keyboard.h
+++ b/tests/mocks/mock_keyboard.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <stdint.h>
+extern uint16_t mock_keyboard_state;
+uint16_t keyboard_get_state(void);

--- a/tests/mocks/mock_ui.c
+++ b/tests/mocks/mock_ui.c
@@ -1,5 +1,14 @@
 #include "mock_ui.h"
+int mock_ui_show_home_count = 0;
+int mock_ui_show_settings_count = 0;
+int mock_ui_show_network_count = 0;
+int mock_ui_show_images_count = 0;
+
 void ui_show_error(const char *msg) { (void)msg; }
 void ui_update_network(const char *ssid, const char *ip, bool ble_connected) {
     (void)ssid; (void)ip; (void)ble_connected;
 }
+void ui_show_home(void) { mock_ui_show_home_count++; }
+void ui_show_settings(void) { mock_ui_show_settings_count++; }
+void ui_show_network(void) { mock_ui_show_network_count++; }
+void ui_show_images(void) { mock_ui_show_images_count++; }

--- a/tests/mocks/mock_ui.h
+++ b/tests/mocks/mock_ui.h
@@ -1,3 +1,11 @@
 #pragma once
 void ui_show_error(const char *msg);
 void ui_update_network(const char *ssid, const char *ip, bool ble_connected);
+extern int mock_ui_show_home_count;
+extern int mock_ui_show_settings_count;
+extern int mock_ui_show_network_count;
+extern int mock_ui_show_images_count;
+void ui_show_home(void);
+void ui_show_settings(void);
+void ui_show_network(void);
+void ui_show_images(void);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -10,6 +10,10 @@ extern void test_power_usage_percent(void);
 extern void test_power_inactivity_timeout(void);
 extern void test_network_init_wifi_init_fail(void);
 extern void test_network_init_wifi_start_fail(void);
+extern void test_menu_home(void);
+extern void test_menu_settings(void);
+extern void test_menu_network(void);
+extern void test_menu_images(void);
 
 void app_main(void)
 {
@@ -20,6 +24,10 @@ void app_main(void)
     RUN_TEST(test_keyboard_initial_state);
     RUN_TEST(test_keyboard_init_gpio_fail);
     RUN_TEST(test_keyboard_init_task_fail);
+    RUN_TEST(test_menu_home);
+    RUN_TEST(test_menu_settings);
+    RUN_TEST(test_menu_network);
+    RUN_TEST(test_menu_images);
     RUN_TEST(test_power_usage_percent);
     RUN_TEST(test_power_inactivity_timeout);
     RUN_TEST(test_network_init_wifi_init_fail);

--- a/tests/test_menu.c
+++ b/tests/test_menu.c
@@ -1,0 +1,35 @@
+#include "unity.h"
+#include "menu.h"
+#include "mock_ui.h"
+#include "mock_keyboard.h"
+
+void setUp(void) {
+    mock_ui_show_home_count = 0;
+    mock_ui_show_settings_count = 0;
+    mock_ui_show_network_count = 0;
+    mock_ui_show_images_count = 0;
+}
+
+void test_menu_home(void)
+{
+    menu_process_keys(1);
+    TEST_ASSERT_EQUAL(1, mock_ui_show_home_count);
+}
+
+void test_menu_settings(void)
+{
+    menu_process_keys(2);
+    TEST_ASSERT_EQUAL(1, mock_ui_show_settings_count);
+}
+
+void test_menu_network(void)
+{
+    menu_process_keys(4);
+    TEST_ASSERT_EQUAL(1, mock_ui_show_network_count);
+}
+
+void test_menu_images(void)
+{
+    menu_process_keys(8);
+    TEST_ASSERT_EQUAL(1, mock_ui_show_images_count);
+}


### PR DESCRIPTION
## Summary
- create new `menu` component for key-based navigation
- highlight active page titles in UI
- integrate menu navigation into main loop
- extend UI mocks and add unit tests for menu navigation

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874dfcda060832397ad55936c18c793