### PR TITLE
Add Wi-Fi configuration screen

### DIFF
--- a/components/network/include/network.h
+++ b/components/network/include/network.h
@@ -8,3 +8,6 @@ esp_err_t network_init(void);
 /** Periodically update Wi-Fi and BLE status on LVGL display */
 void network_update(void);
 
+/** Save Wi-Fi credentials to NVS */
+esp_err_t network_save_credentials(const char *ssid, const char *pass);
+

--- a/components/ui/CMakeLists.txt
+++ b/components/ui/CMakeLists.txt
@@ -1,1 +1,1 @@
-idf_component_register(SRCS "ui.c" INCLUDE_DIRS "include" REQUIRES lvgl display power)
+idf_component_register(SRCS "ui.c" INCLUDE_DIRS "include" REQUIRES lvgl display power network)

--- a/components/ui/include/ui.h
+++ b/components/ui/include/ui.h
@@ -34,6 +34,9 @@ void ui_show_settings(void);
 /** Show network status screen */
 void ui_show_network(void);
 
+/** Show Wi-Fi setup screen */
+void ui_show_wifi_setup(void);
+
 /** Update the network status information */
 void ui_update_network(const char *ssid, const char *ip, bool ble_connected);
 

--- a/tests/mocks/mock_wifi.c
+++ b/tests/mocks/mock_wifi.c
@@ -54,3 +54,30 @@ esp_err_t esp_ble_gatts_register_callback(esp_gatts_cb_t callback) { (void)callb
 esp_err_t esp_ble_gatts_app_register(uint16_t app_id) { (void)app_id; return ESP_OK; }
 esp_err_t esp_ble_gap_start_advertising(const esp_ble_adv_params_t *params) { (void)params; return ESP_OK; }
 
+esp_err_t nvs_open(const char *name, nvs_open_mode_t open_mode, nvs_handle_t *out_handle)
+{
+    (void)name; (void)open_mode; if (out_handle) *out_handle = 1; return ESP_OK;
+}
+
+esp_err_t nvs_get_str(nvs_handle_t handle, const char *key, char *out_value, size_t *length)
+{
+    (void)handle; (void)key;
+    if (out_value && length && *length > 0) { out_value[0] = '\0'; *length = 1; }
+    return ESP_FAIL;
+}
+
+esp_err_t nvs_set_str(nvs_handle_t handle, const char *key, const char *value)
+{
+    (void)handle; (void)key; (void)value; return ESP_OK;
+}
+
+esp_err_t nvs_commit(nvs_handle_t handle)
+{
+    (void)handle; return ESP_OK;
+}
+
+void nvs_close(nvs_handle_t handle)
+{
+    (void)handle;
+}
+

--- a/tests/mocks/mock_wifi.h
+++ b/tests/mocks/mock_wifi.h
@@ -49,3 +49,14 @@ esp_err_t esp_ble_gatts_register_callback(esp_gatts_cb_t callback);
 esp_err_t esp_ble_gatts_app_register(uint16_t app_id);
 esp_err_t esp_ble_gap_start_advertising(const esp_ble_adv_params_t *params);
 
+typedef int32_t nvs_handle_t;
+typedef enum {
+    NVS_READONLY,
+    NVS_READWRITE
+} nvs_open_mode_t;
+esp_err_t nvs_open(const char *name, nvs_open_mode_t open_mode, nvs_handle_t *out_handle);
+esp_err_t nvs_get_str(nvs_handle_t handle, const char *key, char *out_value, size_t *length);
+esp_err_t nvs_set_str(nvs_handle_t handle, const char *key, const char *value);
+esp_err_t nvs_commit(nvs_handle_t handle);
+void nvs_close(nvs_handle_t handle);
+


### PR DESCRIPTION
## Summary
- allow saving Wi-Fi credentials in NVS
- load credentials during `network_init`
- add Wi-Fi setup UI with text areas and save button
- expose `network_save_credentials` API
- provide NVS stubs for unit tests

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6874ed920d688323844a51f21b731ddc