### PR TITLE
Localize warnings and errors

### DIFF
--- a/components/network/network.c
+++ b/components/network/network.c
@@ -43,7 +43,7 @@ static void wifi_event_handler(void *arg, esp_event_base_t event_base,
             ip_addr[0] = '\0';
             esp_wifi_connect();
             wifi_dirty = true;
-            ui_show_error("Wi-Fi disconnected");
+            ui_show_error(ui_get_str(UI_STR_WIFI_DISCONNECTED));
             break;
         default:
             break;
@@ -68,7 +68,7 @@ static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_
         ble_connected = false;
         ble_dirty = true;
         esp_ble_gap_start_advertising(&adv_params);
-        ui_show_error("BLE disconnected");
+        ui_show_error(ui_get_str(UI_STR_BLE_DISCONNECTED));
         break;
     default:
         break;
@@ -81,7 +81,7 @@ esp_err_t network_init(void)
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "nvs_flash_init failed: %s", esp_err_to_name(err));
         char msg[64];
-        snprintf(msg, sizeof(msg), "Net init: %s", esp_err_to_name(err));
+        snprintf(msg, sizeof(msg), ui_get_str(UI_STR_NET_INIT_FAILED), esp_err_to_name(err));
         ui_show_error(msg);
         return err;
     }
@@ -89,7 +89,7 @@ esp_err_t network_init(void)
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_netif_init failed: %s", esp_err_to_name(err));
         char msg[64];
-        snprintf(msg, sizeof(msg), "Net init: %s", esp_err_to_name(err));
+        snprintf(msg, sizeof(msg), ui_get_str(UI_STR_NET_INIT_FAILED), esp_err_to_name(err));
         ui_show_error(msg);
         return err;
     }
@@ -97,7 +97,7 @@ esp_err_t network_init(void)
     if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
         ESP_LOGE(TAG, "esp_event_loop_create_default failed: %s", esp_err_to_name(err));
         char msg[64];
-        snprintf(msg, sizeof(msg), "Net init: %s", esp_err_to_name(err));
+        snprintf(msg, sizeof(msg), ui_get_str(UI_STR_NET_INIT_FAILED), esp_err_to_name(err));
         ui_show_error(msg);
         return err;
     }
@@ -107,7 +107,7 @@ esp_err_t network_init(void)
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_wifi_init failed: %s", esp_err_to_name(err));
         char msg[64];
-        snprintf(msg, sizeof(msg), "Net init: %s", esp_err_to_name(err));
+        snprintf(msg, sizeof(msg), ui_get_str(UI_STR_NET_INIT_FAILED), esp_err_to_name(err));
         ui_show_error(msg);
         return err;
     }
@@ -142,7 +142,7 @@ esp_err_t network_init(void)
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_wifi_set_mode failed: %s", esp_err_to_name(err));
         char msg[64];
-        snprintf(msg, sizeof(msg), "Net init: %s", esp_err_to_name(err));
+        snprintf(msg, sizeof(msg), ui_get_str(UI_STR_NET_INIT_FAILED), esp_err_to_name(err));
         ui_show_error(msg);
         return err;
     }
@@ -150,7 +150,7 @@ esp_err_t network_init(void)
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_wifi_set_config failed: %s", esp_err_to_name(err));
         char msg[64];
-        snprintf(msg, sizeof(msg), "Net init: %s", esp_err_to_name(err));
+        snprintf(msg, sizeof(msg), ui_get_str(UI_STR_NET_INIT_FAILED), esp_err_to_name(err));
         ui_show_error(msg);
         return err;
     }
@@ -160,7 +160,7 @@ esp_err_t network_init(void)
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "wifi handler register failed: %s", esp_err_to_name(err));
         char msg[64];
-        snprintf(msg, sizeof(msg), "Net init: %s", esp_err_to_name(err));
+        snprintf(msg, sizeof(msg), ui_get_str(UI_STR_NET_INIT_FAILED), esp_err_to_name(err));
         ui_show_error(msg);
         return err;
     }
@@ -169,7 +169,7 @@ esp_err_t network_init(void)
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "ip handler register failed: %s", esp_err_to_name(err));
         char msg[64];
-        snprintf(msg, sizeof(msg), "Net init: %s", esp_err_to_name(err));
+        snprintf(msg, sizeof(msg), ui_get_str(UI_STR_NET_INIT_FAILED), esp_err_to_name(err));
         ui_show_error(msg);
         return err;
     }
@@ -178,7 +178,7 @@ esp_err_t network_init(void)
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_wifi_start failed: %s", esp_err_to_name(err));
         char msg[64];
-        snprintf(msg, sizeof(msg), "Net init: %s", esp_err_to_name(err));
+        snprintf(msg, sizeof(msg), ui_get_str(UI_STR_NET_INIT_FAILED), esp_err_to_name(err));
         ui_show_error(msg);
         return err;
     }
@@ -193,7 +193,7 @@ esp_err_t network_init(void)
     if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
         ESP_LOGE(TAG, "bt mem release failed: %s", esp_err_to_name(err));
         char msg[64];
-        snprintf(msg, sizeof(msg), "Net init: %s", esp_err_to_name(err));
+        snprintf(msg, sizeof(msg), ui_get_str(UI_STR_NET_INIT_FAILED), esp_err_to_name(err));
         ui_show_error(msg);
         return err;
     }
@@ -202,7 +202,7 @@ esp_err_t network_init(void)
     if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
         ESP_LOGE(TAG, "bt controller init failed: %s", esp_err_to_name(err));
         char msg[64];
-        snprintf(msg, sizeof(msg), "Net init: %s", esp_err_to_name(err));
+        snprintf(msg, sizeof(msg), ui_get_str(UI_STR_NET_INIT_FAILED), esp_err_to_name(err));
         ui_show_error(msg);
         return err;
     }
@@ -210,7 +210,7 @@ esp_err_t network_init(void)
     if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
         ESP_LOGE(TAG, "bt controller enable failed: %s", esp_err_to_name(err));
         char msg[64];
-        snprintf(msg, sizeof(msg), "Net init: %s", esp_err_to_name(err));
+        snprintf(msg, sizeof(msg), ui_get_str(UI_STR_NET_INIT_FAILED), esp_err_to_name(err));
         ui_show_error(msg);
         return err;
     }
@@ -219,7 +219,7 @@ esp_err_t network_init(void)
     if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
         ESP_LOGE(TAG, "bluedroid init failed: %s", esp_err_to_name(err));
         char msg[64];
-        snprintf(msg, sizeof(msg), "Net init: %s", esp_err_to_name(err));
+        snprintf(msg, sizeof(msg), ui_get_str(UI_STR_NET_INIT_FAILED), esp_err_to_name(err));
         ui_show_error(msg);
         return err;
     }
@@ -227,7 +227,7 @@ esp_err_t network_init(void)
     if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
         ESP_LOGE(TAG, "bluedroid enable failed: %s", esp_err_to_name(err));
         char msg[64];
-        snprintf(msg, sizeof(msg), "Net init: %s", esp_err_to_name(err));
+        snprintf(msg, sizeof(msg), ui_get_str(UI_STR_NET_INIT_FAILED), esp_err_to_name(err));
         ui_show_error(msg);
         return err;
     }

--- a/components/storage_sd/storage_sd.c
+++ b/components/storage_sd/storage_sd.c
@@ -70,7 +70,7 @@ void storage_sd_update(void)
     if (!d) {
         if (!card_missing) {
             ESP_LOGE(TAG, "SD card removed");
-            ui_show_error("SD card removed");
+            ui_show_error(ui_get_str(UI_STR_SD_REMOVED));
             storage_sd_unmount();
             card_missing = true;
         }

--- a/components/ui/include/ui.h
+++ b/components/ui/include/ui.h
@@ -16,6 +16,32 @@ typedef enum {
     UI_PAGE_COUNT
 } ui_page_t;
 
+typedef enum {
+    UI_STR_HOME_TITLE,
+    UI_STR_SETTINGS_TITLE,
+    UI_STR_NETWORK_TITLE,
+    UI_STR_IMAGES_TITLE,
+    UI_STR_ENERGY_USAGE,
+    UI_STR_LANGUAGE_EN,
+    UI_STR_LANGUAGE_FR,
+    UI_STR_BRIGHTNESS,
+    UI_STR_NETWORK_FORMAT,
+    UI_STR_BLE_CONNECTED,
+    UI_STR_BLE_ADVERTISING,
+    UI_STR_WIFI_TITLE,
+    UI_STR_WIFI_SSID,
+    UI_STR_WIFI_PASS,
+    UI_STR_WIFI_SAVE,
+    UI_STR_CALIBRATE,
+    UI_STR_WIFI_DISCONNECTED,
+    UI_STR_BLE_DISCONNECTED,
+    UI_STR_SD_REMOVED,
+    UI_STR_NET_INIT_FAILED,
+    UI_STR_COUNT
+} ui_str_id_t;
+
+const char *ui_get_str(ui_str_id_t id);
+
 /** Load or replace a language table */
 void ui_load_language(ui_lang_t lang, const char *const table[]);
 

--- a/components/ui/ui.c
+++ b/components/ui/ui.c
@@ -25,6 +25,10 @@ typedef enum {
     UI_STR_WIFI_PASS,
     UI_STR_WIFI_SAVE,
     UI_STR_CALIBRATE,
+    UI_STR_WIFI_DISCONNECTED,
+    UI_STR_BLE_DISCONNECTED,
+    UI_STR_SD_REMOVED,
+    UI_STR_NET_INIT_FAILED,
     UI_STR_COUNT
 } ui_str_id_t;
 
@@ -45,7 +49,11 @@ static const char *s_lang_table[UI_LANG_COUNT][UI_STR_COUNT] = {
         "SSID",
         "Password",
         "Save",
-        "Calibrate"
+        "Calibrate",
+        "Wi-Fi disconnected",
+        "BLE disconnected",
+        "SD card removed",
+        "Net init: %s"
     },
     [UI_LANG_FR] = {
         "Accueil",
@@ -63,7 +71,11 @@ static const char *s_lang_table[UI_LANG_COUNT][UI_STR_COUNT] = {
         "SSID",
         "Mot de passe",
         "Sauvegarder",
-        "Calibrer"
+        "Calibrer",
+        "Wi-Fi d\xC3\xA9connect\xC3\xA9",
+        "BLE d\xC3\xA9connect\xC3\xA9",
+        "Carte SD retir\xC3\xA9e",
+        "Init r\xC3\xA9seau : %s"
     }
 };
 
@@ -117,6 +129,11 @@ void ui_load_language(ui_lang_t lang, const char *const table[])
 static const char *get_str(ui_str_id_t id)
 {
     return s_lang_table[s_lang][id];
+}
+
+const char *ui_get_str(ui_str_id_t id)
+{
+    return get_str(id);
 }
 
 static void lang_event_cb(lv_event_t *e)


### PR DESCRIPTION
## Summary
- extend the language table with new warning strings
- expose `ui_get_str` and string IDs
- fetch localized strings in `network.c` and `storage_sd.c`

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874f4f5117883239cc34606592b7d83