### PR TITLE
Document storage_sd memory mgmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,17 @@ Use `storage_sd_init()` to mount the card before loading assets. Call
 `storage_sd_unmount()` prior to removal and invoke `storage_sd_update()` in the
 main loop to detect if the card is unexpectedly removed. When removal is
 detected, an error is logged and displayed on the LVGL interface.
+Use `storage_sd_free()` to release memory obtained from `storage_sd_load()`.
 
-`storage_sd_load()` can read a file directly into memory. For example:
+`storage_sd_load()` can read a file directly into memory. The caller is
+responsible for freeing the returned buffer using `storage_sd_free()` (or
+`free()`). For example:
 
 ```c
 size_t size;
 void *data = storage_sd_load("images/picture.bin", &size);
 lv_img_set_src(img, data);
+storage_sd_free(data);
 ```
 
 ### Language Selection

--- a/components/storage_sd/include/storage_sd.h
+++ b/components/storage_sd/include/storage_sd.h
@@ -8,6 +8,9 @@ esp_err_t storage_sd_init(void);
 /** Load a file into memory from the SD card */
 void *storage_sd_load(const char *path, size_t *size);
 
+/** Free memory allocated by storage_sd_load() */
+void storage_sd_free(void *buf);
+
 /** Unmount the microSD card */
 esp_err_t storage_sd_unmount(void);
 

--- a/components/storage_sd/storage_sd.c
+++ b/components/storage_sd/storage_sd.c
@@ -53,6 +53,11 @@ void *storage_sd_load(const char *path, size_t *size)
     return buf;
 }
 
+void storage_sd_free(void *buf)
+{
+    free(buf);
+}
+
 esp_err_t storage_sd_unmount(void)
 {
     if (!sdcard) {


### PR DESCRIPTION
## Summary
- mention freeing buffers in README
- provide `storage_sd_free()` to release loaded data

## Testing
- `idf.py test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875047547b88323ac6b2d96dff3a51b